### PR TITLE
Add structure for network behaviour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /target
 Cargo.lock
 locha-p2pd/secret_key
+
+# Files from tests
+id.key

--- a/locha-p2pd/src/arguments.rs
+++ b/locha-p2pd/src/arguments.rs
@@ -25,7 +25,11 @@ pub struct Arguments {
     pub dials: Vec<Multiaddr>,
     pub identity: PathBuf,
     pub echo: bool,
-    pub tui: bool,
+
+    pub use_mdns: bool,
+    pub allow_ipv4_private: bool,
+    pub allow_ipv6_link_local: bool,
+    pub allow_ipv6_ula: bool,
 }
 
 impl Arguments {
@@ -40,15 +44,19 @@ impl Arguments {
         };
         let identity = value_t!(matches.value_of("identity"), PathBuf)
             .unwrap_or_else(|e| e.exit());
-        let echo = matches.is_present("echo");
-        let tui = matches.is_present("tui");
 
         Arguments {
             listen_addr,
             dials,
             identity,
-            echo,
-            tui,
+            echo: matches.is_present("echo"),
+
+            use_mdns: matches.is_present("use-mdns"),
+            allow_ipv4_private: matches.is_present("allow-ipv4-private")
+                || matches.is_present("allow-mdns"),
+            allow_ipv6_link_local: matches.is_present("allow-ipv6-link-local")
+                || matches.is_present("allow-mdns"),
+            allow_ipv6_ula: matches.is_present("allow-ipv6-ula"),
         }
     }
 }

--- a/locha-p2pd/src/cli.yml
+++ b/locha-p2pd/src/cli.yml
@@ -15,6 +15,7 @@ args:
         long: dial
         value_name: multiaddr
         help: Dial a peer using it's multiaddress.
+        multiple: true
     - identity:
         short: id
         long: identity
@@ -25,3 +26,15 @@ args:
     - echo:
         long: echo
         help: Enable testing by echoing messages from the Locha Mesh Chat application.
+    - allow-ipv4-private:
+        long: allow-ipv4-private
+        help: Enable discovery of IPv4 private addresses.
+    - allow-ipv6-link-local:
+        long: allow-ipv6-link-local
+        help: Enable discovery of IPv6 link local addresses (fe80::/16).
+    - allow-ipv6-ula:
+        long: allow-ipv6-ula
+        help: Enable discovery of IPv6 Unique Local Addresses (fc00::/7)
+    - use-mdns:
+        long: use-mdns
+        help: Enable discovery through mDNS. This also enables --allow-ipv4-private and --allow-ipv6-link-local

--- a/locha-p2pd/src/main.rs
+++ b/locha-p2pd/src/main.rs
@@ -97,9 +97,7 @@ impl RuntimeEvents for EventsHandler {
         }
     }
 
-    fn on_new_listen_addr(&mut self, multiaddr: Multiaddr) {
-        info!("new listen addr: {}", multiaddr)
-    }
+    fn on_new_listen_addr(&mut self, _multiaddr: Multiaddr) {}
 }
 
 #[derive(Deserialize, Serialize)]
@@ -152,6 +150,11 @@ fn main() {
         channel_cap: 25,
         heartbeat_interval: 10,
         listen_addr: arguments.listen_addr,
+
+        use_mdns: arguments.use_mdns,
+        allow_ipv4_private: arguments.allow_ipv4_private,
+        allow_ipv6_link_local: arguments.allow_ipv6_link_local,
+        allow_ipv6_ula: arguments.allow_ipv6_ula,
     };
 
     let (sender, receiver) = channel::<Message>(10);

--- a/locha-p2pd/src/main.rs
+++ b/locha-p2pd/src/main.rs
@@ -132,7 +132,7 @@ struct Message {
 
 fn main() {
     env_logger::Builder::new()
-        .filter_level(log::LevelFilter::Info)
+        .filter_level(log::LevelFilter::Trace)
         .init();
 
     let cli_yaml = load_yaml!("cli.yml");

--- a/locha-p2pd/src/main.rs
+++ b/locha-p2pd/src/main.rs
@@ -31,9 +31,9 @@ use serde_derive::{Deserialize, Serialize};
 
 use locha_p2p::identity::Identity;
 use locha_p2p::runtime::config::RuntimeConfig;
-use locha_p2p::runtime::events::RuntimeEvents;
+use locha_p2p::runtime::events::{RuntimeEvents, RuntimeEventsLogger};
 use locha_p2p::runtime::Runtime;
-use locha_p2p::Multiaddr;
+use locha_p2p::{Multiaddr, PeerId};
 
 use log::{info, trace};
 
@@ -97,7 +97,11 @@ impl RuntimeEvents for EventsHandler {
         }
     }
 
-    fn on_new_listen_addr(&mut self, _multiaddr: Multiaddr) {}
+    fn on_new_listen_addr(&mut self, _multiaddr: &Multiaddr) {}
+
+    fn on_peer_discovered(&mut self, _peer: &PeerId, _addrs: Vec<Multiaddr>) {}
+
+    fn on_peer_unroutable(&mut self, _peer: &PeerId) {}
 }
 
 #[derive(Deserialize, Serialize)]
@@ -164,7 +168,7 @@ fn main() {
     };
 
     runtime
-        .start(config, Box::new(events_handler))
+        .start(config, Box::new(RuntimeEventsLogger::new(events_handler)))
         .expect("couldn't start chat service");
 
     // Reach out to another node if specified

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -1,0 +1,417 @@
+// Copyright 2020 Bitcoin Venezuela and Locha Mesh Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # Discovery behaviour
+
+use std::collections::VecDeque;
+use std::task::{Context, Poll};
+
+use libp2p::kad::handler::{KademliaHandler, KademliaHandlerEvent};
+use libp2p::kad::record::store::MemoryStore;
+use libp2p::kad::{Kademlia, KademliaConfig, KademliaEvent, QueryId};
+
+use libp2p::mdns::{Mdns, MdnsEvent};
+
+use libp2p::core::connection::ConnectionId;
+use libp2p::swarm::{NetworkBehaviour, NetworkBehaviourAction};
+use libp2p::swarm::{PollParameters, ProtocolsHandler};
+
+use libp2p::core::multiaddr::Protocol;
+use libp2p::{Multiaddr, PeerId};
+
+use log::{debug, error, info};
+
+pub const LOCHA_KAD_PROTOCOL_NAME: &[u8] = b"/locha/kad/1.0.0";
+
+/// Builder for [`DiscoveryBehaviour`](struct.DiscoveryBehaviour.html).
+#[derive(Debug)]
+pub struct DiscoveryBuilder {
+    use_mdns: bool,
+
+    allow_ipv4_private: bool,
+    allow_ipv6_link_local: bool,
+    allow_ipv6_ula: bool,
+    id: Option<PeerId>,
+}
+
+impl DiscoveryBuilder {
+    /// Create a new [`DiscoveryBehaviour`](struct.DiscoveryBehaviour.html)
+    /// builder.
+    pub fn new() -> DiscoveryBuilder {
+        DiscoveryBuilder {
+            use_mdns: false,
+
+            allow_ipv4_private: false,
+            allow_ipv6_link_local: false,
+            allow_ipv6_ula: false,
+            id: None,
+        }
+    }
+
+    /// Use mDNs for peer discovery?
+    pub fn use_mdns(&mut self, v: bool) -> &mut Self {
+        self.use_mdns = v;
+        self
+    }
+
+    /// Allow IPv4 private addresses?
+    ///
+    /// Address ranges considered private:
+    ///
+    /// - 10.0.0.0/8
+    /// - 172.16.0.0/12
+    /// - 192.168.0.0/16
+    pub fn allow_ipv4_private(&mut self, v: bool) -> &mut Self {
+        self.allow_ipv4_private = v;
+        self
+    }
+
+    /// Allow IPv6 link local addresses (fe00::/7)?
+    pub fn allow_ipv6_link_local(&mut self, v: bool) -> &mut Self {
+        self.allow_ipv6_link_local = v;
+        self
+    }
+
+    /// Allow unique local addresses (fc00::/7)?
+    pub fn allow_ipv6_ula(&mut self, v: bool) -> &mut Self {
+        self.allow_ipv6_ula = v;
+        self
+    }
+
+    /// Peer Id of the node discovering peers.
+    pub fn id(&mut self, id: PeerId) -> &mut Self {
+        self.id = Some(id);
+        self
+    }
+
+    /// Build the discovery behaviour.
+    pub fn build(&mut self) -> DiscoveryBehaviour {
+        let id = self
+            .id
+            .clone()
+            .expect("PeerId is necessary to participate in Peer Discovery");
+
+        let mut kad_config = KademliaConfig::default();
+        kad_config.set_protocol_name(LOCHA_KAD_PROTOCOL_NAME);
+
+        DiscoveryBehaviour {
+            mdns: if self.use_mdns {
+                match Mdns::new() {
+                    Ok(m) => {
+                        info!(target: "locha-p2p", "using mDNS for peer discovery");
+                        Some(m)
+                    }
+                    Err(e) => {
+                        error!(target: "locha-p2p", "failed to initialize mDNS: {}", e);
+                        None
+                    }
+                }
+            } else {
+                None
+            },
+            kademlia: Kademlia::with_config(
+                id.clone(),
+                MemoryStore::new(id),
+                kad_config,
+            ),
+            pending_events: VecDeque::new(),
+
+            allow_ipv4_private: self.allow_ipv4_private,
+            allow_ipv6_link_local: self.allow_ipv6_link_local,
+            allow_ipv6_ula: self.allow_ipv6_ula,
+        }
+    }
+}
+
+impl Default for DiscoveryBuilder {
+    fn default() -> DiscoveryBuilder {
+        DiscoveryBuilder::new()
+    }
+}
+
+/// Discovery behaviour
+pub struct DiscoveryBehaviour {
+    /// Mdns to locate neighboring peers
+    mdns: Option<Mdns>,
+    /// Kademlia network behaviour
+    kademlia: Kademlia<MemoryStore>,
+    pending_events: VecDeque<DiscoveryEvent>,
+
+    allow_ipv4_private: bool,
+    allow_ipv6_link_local: bool,
+    allow_ipv6_ula: bool,
+}
+
+impl DiscoveryBehaviour {
+    #[rustfmt::skip]
+    fn is_address_allowed(&self, addr: &Multiaddr) -> bool {
+        (self.allow_ipv4_private && is_ipv4_private(&addr)) ||
+        (self.allow_ipv6_link_local && is_ipv6_link_local(&addr)) ||
+        (self.allow_ipv6_ula && is_ipv6_ula(addr))
+    }
+}
+
+pub enum DiscoveryEvent {
+    Discovered(PeerId),
+    UnroutablePeer(PeerId),
+}
+
+impl NetworkBehaviour for DiscoveryBehaviour {
+    type ProtocolsHandler = KademliaHandler<QueryId>;
+    type OutEvent = DiscoveryEvent;
+
+    fn new_handler(&mut self) -> Self::ProtocolsHandler {
+        NetworkBehaviour::new_handler(&mut self.kademlia)
+    }
+
+    fn addresses_of_peer(&mut self, id: &PeerId) -> Vec<Multiaddr> {
+        let mut ret = Vec::new();
+        for addr in self.kademlia.addresses_of_peer(id) {
+            if !self.is_address_allowed(&addr) {
+                debug!(
+                    target: "locha-p2p",
+                    "Kad address {} not allowed",
+                    addr
+                );
+                continue;
+            }
+
+            ret.push(addr);
+        }
+
+        if let Some(ref mut mdns) = self.mdns {
+            for addr in mdns.addresses_of_peer(id) {
+                if !self.is_address_allowed(&addr) {
+                    debug!(
+                        target: "locha-p2p",
+                        "mDNS address {} not allowed",
+                        addr
+                    );
+                    continue;
+                }
+
+                ret.push(addr);
+            }
+        }
+
+        ret
+    }
+
+    fn inject_disconnected(&mut self, id: &PeerId) {
+        self.kademlia.inject_disconnected(id)
+    }
+
+    fn inject_connected(&mut self, id: &PeerId) {
+        self.kademlia.inject_connected(id)
+    }
+
+    fn inject_event(
+        &mut self,
+        source: PeerId,
+        connection: ConnectionId,
+        event: KademliaHandlerEvent<QueryId>,
+    ) {
+        self.kademlia.inject_event(source, connection, event)
+    }
+
+    fn poll(
+        &mut self,
+        cx: &mut Context<'_>,
+        parameters: &mut impl PollParameters,
+    ) -> Poll<
+        NetworkBehaviourAction<
+            <Self::ProtocolsHandler as ProtocolsHandler>::InEvent,
+            Self::OutEvent,
+        >,
+    > {
+        // Process pending events first
+        if let Some(ev) = self.pending_events.pop_front() {
+            return Poll::Ready(NetworkBehaviourAction::GenerateEvent(ev));
+        }
+
+        // Process Kademlia, they might get us some good data than other methods
+        // as it's the state of the network.
+        while let Poll::Ready(action) = self.kademlia.poll(cx, parameters) {
+            match action {
+                NetworkBehaviourAction::GenerateEvent(ev) => {
+                    let result = match ev {
+                        KademliaEvent::QueryResult { .. } => {
+                            debug!(target: "locha-p2p", "query result produced");
+                            Poll::Pending
+                        }
+                        KademliaEvent::RoutingUpdated { peer, .. } => {
+                            debug!(target: "locha-p2p", "routing updated {}", peer);
+                            let event = DiscoveryEvent::Discovered(peer);
+                            Poll::Ready(NetworkBehaviourAction::GenerateEvent(
+                                event,
+                            ))
+                        }
+                        KademliaEvent::UnroutablePeer { peer } => {
+                            debug!(target: "locha-p2p", "unroutable peer {}", peer);
+                            let event = DiscoveryEvent::UnroutablePeer(peer);
+                            Poll::Ready(NetworkBehaviourAction::GenerateEvent(
+                                event,
+                            ))
+                        }
+                        KademliaEvent::RoutablePeer { peer, .. } => {
+                            debug!(target: "locha-p2p", "routable peer {}", peer);
+                            let event = DiscoveryEvent::Discovered(peer);
+                            Poll::Ready(NetworkBehaviourAction::GenerateEvent(
+                                event,
+                            ))
+                        }
+                        KademliaEvent::PendingRoutablePeer { peer, .. } => {
+                            debug!(target: "locha-p2p", "pending routable peer {}", peer);
+                            Poll::Pending
+                        }
+                    };
+
+                    // Return only if we have an event.
+                    if let Poll::Ready(_) = result {
+                        return result;
+                    }
+                }
+                NetworkBehaviourAction::DialAddress { address } => {
+                    return Poll::Ready(NetworkBehaviourAction::DialAddress {
+                        address,
+                    });
+                }
+                NetworkBehaviourAction::DialPeer { peer_id, condition } => {
+                    return Poll::Ready(NetworkBehaviourAction::DialPeer {
+                        peer_id,
+                        condition,
+                    });
+                }
+                NetworkBehaviourAction::NotifyHandler {
+                    peer_id,
+                    handler,
+                    event,
+                } => {
+                    return Poll::Ready(
+                        NetworkBehaviourAction::NotifyHandler {
+                            peer_id,
+                            handler,
+                            event,
+                        },
+                    );
+                }
+                NetworkBehaviourAction::ReportObservedAddr { address } => {
+                    return Poll::Ready(
+                        NetworkBehaviourAction::ReportObservedAddr { address },
+                    );
+                }
+            }
+        }
+
+        // Poll mDNS to see if we found out nodes on our local network.
+        if let Some(ref mut mdns) = self.mdns {
+            while let Poll::Ready(action) = mdns.poll(cx, parameters) {
+                match action {
+                    NetworkBehaviourAction::GenerateEvent(event) => match event
+                    {
+                        MdnsEvent::Discovered(addrs) => {
+                            for (peer, addr) in addrs {
+                                debug!(target: "locha-p2p", "mDNS discovered peer {} on {}", peer, addr);
+                                self.pending_events.push_back(
+                                    DiscoveryEvent::Discovered(peer),
+                                );
+                            }
+
+                            if let Some(ev) = self.pending_events.pop_front() {
+                                return Poll::Ready(
+                                    NetworkBehaviourAction::GenerateEvent(ev),
+                                );
+                            }
+                        }
+                        MdnsEvent::Expired(_) => {
+                            debug!(target: "locha-p2p", "mDNS expired some peers");
+                        }
+                    },
+                    NetworkBehaviourAction::DialAddress { address } => {
+                        return Poll::Ready(
+                            NetworkBehaviourAction::DialAddress { address },
+                        );
+                    }
+                    NetworkBehaviourAction::DialPeer { peer_id, condition } => {
+                        return Poll::Ready(NetworkBehaviourAction::DialPeer {
+                            peer_id,
+                            condition,
+                        });
+                    }
+                    NetworkBehaviourAction::NotifyHandler { event, .. } => {
+                        // has no variants
+                        match event {}
+                    }
+                    NetworkBehaviourAction::ReportObservedAddr { address } => {
+                        return Poll::Ready(
+                            NetworkBehaviourAction::ReportObservedAddr {
+                                address,
+                            },
+                        );
+                    }
+                }
+            }
+        }
+
+        Poll::Pending
+    }
+}
+
+/// Is the multiaddress an IPv4 private address?
+fn is_ipv4_private(addr: &Multiaddr) -> bool {
+    let res = addr.iter().next().map(|p| {
+        if let Protocol::Ip4(ipv4) = p {
+            ipv4.is_private()
+        } else {
+            false
+        }
+    });
+
+    match res {
+        Some(v) => v,
+        None => false,
+    }
+}
+
+/// Is the multiaddress a link local IPv6?
+fn is_ipv6_link_local(addr: &Multiaddr) -> bool {
+    let res = addr.iter().next().map(|p| {
+        if let Protocol::Ip6(ipv6) = p {
+            (ipv6.segments()[0] & 0xffc0) == 0xfe80
+        } else {
+            false
+        }
+    });
+
+    match res {
+        Some(v) => v,
+        None => false,
+    }
+}
+
+/// Is the multiaddress an IPv6 ULA?
+fn is_ipv6_ula(addr: &Multiaddr) -> bool {
+    let res = addr.iter().next().map(|p| {
+        if let Protocol::Ip6(ipv6) = p {
+            (ipv6.segments()[0] & 0xfe00) == 0xfc00
+        } else {
+            false
+        }
+    });
+
+    match res {
+        Some(v) => v,
+        None => false,
+    }
+}

--- a/src/gossip.rs
+++ b/src/gossip.rs
@@ -1,0 +1,88 @@
+// Copyright 2020 Bitcoin Venezuela and Locha Mesh Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # Gosssipsub behaviour
+
+use std::time::Duration;
+
+use libp2p::gossipsub::GossipsubConfig;
+use libp2p::gossipsub::GossipsubConfigBuilder;
+use libp2p::gossipsub::{GossipsubMessage, MessageAuthenticity, MessageId};
+
+use crate::identity::Identity;
+
+pub use libp2p::gossipsub::error::PublishError;
+pub use libp2p::gossipsub::{Gossipsub, GossipsubEvent, Topic};
+
+/// Gossipsub protocol name for Locha P2P Chat
+pub const CHAT_SERVICE_GOSSIP_PROTCOL_ID: &[u8] = b"/locha/gossip/1.0.0";
+
+/// New gossipsub behaviour
+pub fn new(identity: &Identity) -> Gossipsub {
+    Gossipsub::new(
+        MessageAuthenticity::Signed(identity.keypair()),
+        gossipsub_config(),
+    )
+}
+
+/// Generate Gossipsub configuration
+fn gossipsub_config() -> GossipsubConfig {
+    GossipsubConfigBuilder::new()
+        .protocol_id(CHAT_SERVICE_GOSSIP_PROTCOL_ID)
+        .heartbeat_interval(Duration::from_secs(5))
+        .message_id_fn(gossipsub_message_id)
+        .build()
+}
+
+/// Calculate MessageId for a Gossipsub message.
+///
+/// We use Keccak-384 because it's fast, lightweight, with not known attacks
+/// and very little probabilities of collisions.
+fn gossipsub_message_id(message: &GossipsubMessage) -> MessageId {
+    use libp2p::multihash::{Keccak384, MultihashDigest};
+
+    let mut hasher = Keccak384::default();
+    hasher.input(message.data.as_slice());
+
+    MessageId::from(hasher.result().into_bytes())
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    #[test]
+    fn gossipsub_config_ok() {
+        // GossipsubConfigBuilder can generate panics on invalid values
+        gossipsub_config();
+    }
+
+    #[test]
+    fn gossipsub_message_id_works() {
+        use libp2p::gossipsub::GossipsubMessage;
+
+        let message = GossipsubMessage {
+            source: None,
+            data: vec![0xca, 0xfe, 0xca, 0xfe],
+            sequence_number: None,
+            topics: vec![],
+            signature: None,
+            key: None,
+            validated: false,
+        };
+
+        let id = gossipsub_message_id(&message);
+        assert_eq!(id.to_string(), "1c30927f61ecac8caeccc3db58f0b48d6468a4bbdfeb178f9b9ce97147abeed66b39d361996173fed138c7cee4e08ac18fae".to_string());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 Locha Inc
+// Copyright 2020 Bitcoin Venezuela and Locha Mesh Developers
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,8 +21,14 @@
 #![doc(html_logo_url = "https://locha.io/i/128.png")]
 #![doc(html_favicon_url = "https://locha.io/i/128.png")]
 
+pub mod discovery;
+pub mod gossip;
 pub mod identity;
+pub mod network;
 pub mod runtime;
 
 pub use libp2p::Multiaddr;
 pub use libp2p::PeerId;
+
+mod transport;
+pub use transport::build_transport;

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,0 +1,70 @@
+// Copyright 2020 Bitcoin Venezuela and Locha Mesh Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use libp2p::NetworkBehaviour;
+
+use crate::discovery::{DiscoveryBehaviour, DiscoveryEvent};
+use crate::gossip::{Gossipsub, GossipsubEvent, PublishError, Topic};
+
+use crate::identity::Identity;
+
+#[derive(NetworkBehaviour)]
+#[behaviour(event_process = false)]
+#[behaviour(out_event = "NetworkEvent")]
+pub struct Network {
+    discovery: DiscoveryBehaviour,
+    gossip: Gossipsub,
+}
+
+impl Network {
+    pub fn with_discovery(
+        identity: &Identity,
+        discovery: DiscoveryBehaviour,
+    ) -> Network {
+        Network {
+            discovery,
+            gossip: crate::gossip::new(identity),
+        }
+    }
+
+    pub fn subscribe(&mut self, topic: Topic) -> bool {
+        self.gossip.subscribe(topic)
+    }
+
+    pub fn publish(
+        &mut self,
+        topic: &Topic,
+        data: impl Into<Vec<u8>>,
+    ) -> Result<(), PublishError> {
+        self.gossip.publish(topic, data)
+    }
+}
+
+/// Network behaviour event
+pub enum NetworkEvent {
+    Discovery(DiscoveryEvent),
+    Gossipsub(Box<GossipsubEvent>),
+}
+
+impl From<DiscoveryEvent> for NetworkEvent {
+    fn from(event: DiscoveryEvent) -> NetworkEvent {
+        NetworkEvent::Discovery(event)
+    }
+}
+
+impl From<GossipsubEvent> for NetworkEvent {
+    fn from(event: GossipsubEvent) -> NetworkEvent {
+        NetworkEvent::Gossipsub(Box::new(event))
+    }
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -508,10 +508,11 @@ impl Runtime {
             }
             NetworkEvent::Discovery(ref disc_ev) => match *disc_ev {
                 DiscoveryEvent::Discovered(ref peer) => {
-                    info!(target: "locha-p2p", "discovered peer {}", peer);
+                    let addrs = swarm.addresses_of_peer(peer);
+                    events_handler.on_peer_discovered(peer, addrs);
                 }
                 DiscoveryEvent::UnroutablePeer(ref peer) => {
-                    info!(target: "locha-p2p", "unreachable peer {}", peer);
+                    events_handler.on_peer_unroutable(peer);
                 }
             },
         }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 Locha Inc
+// Copyright 2020 Bitcoin Venezuela and Locha Mesh Developers
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -47,6 +47,16 @@
 //!     listen_addr: "/ip4/0.0.0.0/tcp/0".parse().expect("invalid address"),
 //!     channel_cap: 20,
 //!     heartbeat_interval: 5,
+//!
+//!     // Yes, allow discovery of private IPv4 adddresses
+//!     allow_ipv4_private: true,
+//!     allow_ipv6_link_local: true,
+//!     // Allow discovery of IPv6 unique local addresses which are used
+//!     // by Locha Mesh, cjdns and private networks not reachable on the
+//!     // public internet.
+//!     allow_ipv6_ula: true,
+//!     // Allow discovery through mDNS
+//!     use_mdns: true,
 //! };
 //!
 //! let mut runtime = Runtime::new();
@@ -66,7 +76,6 @@ pub mod events;
 pub mod sync_start_cond;
 
 use std::io;
-use std::time::Duration;
 
 use async_std::sync::{channel, Receiver, Sender};
 use async_std::task;
@@ -77,23 +86,23 @@ use futures::select;
 use libp2p::core::connection::{ConnectedPoint, ConnectionError};
 use libp2p::swarm::protocols_handler::NodeHandlerWrapperError;
 use libp2p::swarm::{Swarm, SwarmEvent};
-use libp2p::Transport;
 
-use libp2p::gossipsub::GossipsubEvent;
-use libp2p::gossipsub::{Gossipsub, GossipsubConfigBuilder, MessageId};
-use libp2p::gossipsub::{GossipsubMessage, MessageAuthenticity, Topic};
+use libp2p::core::either::EitherError;
 
-use libp2p::identity::Keypair;
 use libp2p::{Multiaddr, PeerId};
 
-use log::{error, info, trace, warn};
+use log::{debug, error, info, trace, warn};
 
 use self::config::RuntimeConfig;
 use self::error::Error;
 use self::events::RuntimeEvents;
 use self::sync_start_cond::{StartStatus, SyncStartCond};
 
+use crate::discovery::{DiscoveryBuilder, DiscoveryEvent};
+use crate::gossip::{GossipsubEvent, Topic};
 use crate::identity::Identity;
+use crate::network::{Network, NetworkEvent};
+use crate::transport::build_transport;
 
 /// Gossipsub protocol name for Locha P2P Chat
 pub const CHAT_SERVICE_GOSSIP_PROTCOL_NAME: &[u8] = b"/locha-gossip/1.0.0";
@@ -101,7 +110,7 @@ pub const CHAT_SERVICE_GOSSIP_PROTCOL_NAME: &[u8] = b"/locha-gossip/1.0.0";
 /// Locha P2P runtime
 pub struct Runtime {
     handle: Option<task::JoinHandle<Result<(), Error>>>,
-    tx: Option<Sender<ChatAction>>,
+    tx: Option<Sender<RuntimeAction>>,
 
     identity: Option<Identity>,
 }
@@ -109,7 +118,7 @@ pub struct Runtime {
 impl Runtime {
     /// Create a new runtime
     pub fn new() -> Runtime {
-        trace!("creating new Runtime");
+        trace!(target: "locha-p2p", "creating new Runtime");
 
         Runtime {
             handle: None,
@@ -140,14 +149,14 @@ impl Runtime {
         config: RuntimeConfig,
         events_handler: Box<dyn RuntimeEvents>,
     ) -> Result<(), Error> {
-        trace!("starting chat service");
+        trace!(target: "locha-p2p", "starting chat service");
 
         if self.is_started() {
-            warn!("chat service is already started");
+            warn!(target: "locha-p2p", "chat service is already started");
             return Err(Error::AlreadyStarted);
         }
 
-        let (tx, rx) = channel::<ChatAction>(config.channel_cap);
+        let (tx, rx) = channel::<RuntimeAction>(config.channel_cap);
 
         let identity = config.identity.clone();
 
@@ -172,10 +181,10 @@ impl Runtime {
     /// Stop the runtime. This function will block until the runtime
     /// is closed.
     pub fn stop(&mut self) -> Result<(), Error> {
-        trace!("stopping chat service");
+        debug!(target: "locha-p2p", "stopping chat service");
 
         if !self.is_started() {
-            error!("chat service is not started");
+            error!(target: "locha-p2p", "chat service is not started");
             return Err(Error::NotStarted);
         }
 
@@ -185,7 +194,7 @@ impl Runtime {
         }
 
         // Send Stop action and wait for thread to finish.
-        self.send_action(ChatAction::Stop)?;
+        self.send_action(RuntimeAction::Stop)?;
         task::block_on(async { self.handle.as_mut().unwrap().await })?;
 
         self.handle = None;
@@ -196,23 +205,23 @@ impl Runtime {
 
     /// Dial a peer using it's multiaddress
     pub fn dial(&self, multiaddr: Multiaddr) -> Result<(), Error> {
-        trace!("sending dial: {}", multiaddr);
+        trace!(target: "locha-p2p", "sending dial: {}", multiaddr);
 
-        self.send_action(ChatAction::Dial(multiaddr))
+        self.send_action(RuntimeAction::Dial(multiaddr))
     }
 
     /// Send a message
     pub fn send_message(&self, message: String) -> Result<(), Error> {
-        trace!("sending message");
+        trace!(target: "locha-p2p", "sending message");
 
-        self.send_action(ChatAction::SendMessage(message))
+        self.send_action(RuntimeAction::SendMessage(message))
     }
 
     /// Send an action to the event loop.
-    fn send_action(&self, action: ChatAction) -> Result<(), Error> {
+    fn send_action(&self, action: RuntimeAction) -> Result<(), Error> {
         if self.tx.is_none() {
             if self.handle.is_none() {
-                error!("Runtime is not initialized");
+                error!(target: "locha-p2p", "Runtime is not initialized");
             }
 
             return Err(Error::ChannelClosed);
@@ -222,130 +231,96 @@ impl Runtime {
         Ok(())
     }
 
-    /// Builds the transport we're going to use
-    fn build_transport(
-        keypair: Keypair,
-    ) -> std::io::Result<
-        impl Transport<
-                Output = (
-                    PeerId,
-                    impl libp2p::core::muxing::StreamMuxer<
-                            OutboundSubstream = impl Send,
-                            Substream = impl Send,
-                            Error = impl Into<std::io::Error>,
-                        > + Send
-                        + Sync,
-                ),
-                Error = impl std::error::Error + Send,
-                Listener = impl Send,
-                Dial = impl Send,
-                ListenerUpgrade = impl Send,
-            > + Clone,
-    > {
-        use libp2p::core::upgrade::{SelectUpgrade, Version};
-        use libp2p::dns::DnsConfig;
-        use libp2p::noise;
-        use libp2p::tcp::TcpConfig;
-        use libp2p::websocket::WsConfig;
-
-        // Create our low level TCP transport, and on top of it create a
-        // WebSockets transport. They can be used both at the same time.
-        let tcp = TcpConfig::new().nodelay(true);
-        let dns = DnsConfig::new(tcp)?;
-        let ws = WsConfig::new(dns.clone());
-        let transport = dns.or_transport(ws);
-
-        // Use the noise protocol to handle encryption and negotiation.
-        // Also we use yamux and mplex to multiplex connections to peers.
-        let noise_keys = noise::Keypair::<noise::X25519Spec>::new()
-            .into_authentic(&keypair)
-            .expect("Signing noise static DH keypair failed.");
-
-        Ok(transport
-            .upgrade(Version::V1)
-            .authenticate(
-                noise::NoiseConfig::xx(noise_keys).into_authenticated(),
-            )
-            .multiplex(SelectUpgrade::new(
-                libp2p::yamux::Config::default(),
-                libp2p::mplex::MplexConfig::default(),
-            ))
-            .map(|(peer, muxer), _| {
-                (peer, libp2p::core::muxing::StreamMuxerBox::new(muxer))
-            })
-            .timeout(Duration::from_secs(20)))
-    }
-
-    fn message_id(message: &GossipsubMessage) -> MessageId {
-        use libp2p::multihash::{Keccak384, MultihashDigest};
-
-        let mut hasher = Keccak384::default();
-        hasher.input(message.data.as_slice());
-
-        MessageId::from(hasher.result().into_bytes())
-    }
-
     /// Main event loop of the Chat Service. This is where we handle all logic
     /// from libp2p and the network behaviour and also we handle our own actions
     /// as sending a message or dialing a node.
     async fn event_loop(
         cond: SyncStartCond,
-        rx: Receiver<ChatAction>,
+        rx: Receiver<RuntimeAction>,
         config: RuntimeConfig,
         mut events_handler: Box<dyn RuntimeEvents>,
     ) -> Result<(), Error> {
-        let transport = Self::build_transport(config.identity.keypair())?;
+        let transport = match build_transport(&config.identity.keypair()) {
+            Ok(t) => t,
+            Err(e) => {
+                error!(
+                    target: "locha-p2p",
+                    "Could not create transport: {}",
+                    e
+                );
+                cond.notify_failure();
+                return Err(e.into());
+            }
+        };
 
-        let gossipsub_config = GossipsubConfigBuilder::new()
-            .protocol_id(CHAT_SERVICE_GOSSIP_PROTCOL_NAME)
-            .heartbeat_interval(Duration::from_secs(config.heartbeat_interval))
-            .message_id_fn(Self::message_id)
-            .build();
+        let mut discovery = DiscoveryBuilder::new();
+
+        discovery
+            .id(config.identity.id())
+            .use_mdns(config.use_mdns)
+            .allow_ipv4_private(config.allow_ipv4_private)
+            .allow_ipv6_link_local(config.allow_ipv6_link_local)
+            .allow_ipv6_ula(config.allow_ipv6_ula);
+
+        let mut network =
+            Network::with_discovery(&config.identity, discovery.build());
 
         // Create a Gossipsub topic
         // TODO: Make topics dynamic per peer
         let topic = Topic::new("locha-p2p-testnet".into());
+        network.subscribe(topic.clone());
 
-        let mut gossipsub = Gossipsub::new(
-            MessageAuthenticity::Signed(config.identity.keypair()),
-            gossipsub_config,
-        );
-        gossipsub.subscribe(topic.clone());
-
-        let mut swarm = Swarm::new(transport, gossipsub, config.identity.id());
+        let mut swarm = Swarm::new(transport, network, config.identity.id());
         match Swarm::listen_on(&mut swarm, config.listen_addr.clone()) {
             Ok(_) => (),
             Err(e) => {
-                error!("Could not listen on {}: {}", config.listen_addr, e);
+                error!(
+                    target: "locha-p2p",
+                    "Could not listen on {}: {}",
+                    config.listen_addr, e
+                );
                 cond.notify_failure();
                 return Err(e.into());
             }
         }
 
+        // Signal the calling thread we already started.
         cond.notify_start();
 
         loop {
             select! {
                 action = rx.recv().fuse() => {
                     if action.is_err() {
-                        warn!("Channel has been dropped without exiting properly");
+                        warn!(
+                            target: "locha-p2p",
+                            "Channel has been dropped without asking to stop"
+                        );
                         break;
                     }
 
                     let action = action.unwrap();
 
                     match action {
-                        ChatAction::Stop => {
-                            info!("Stopping chat service");
+                        RuntimeAction::Stop => {
+                            info!(target: "locha-p2p", "Stopping chat service");
                             break;
                         },
-                        ChatAction::Dial(to_dial) => {
-                            info!("Dialing address: {}", to_dial);
+                        RuntimeAction::Dial(to_dial) => {
+                            debug!(
+                                target: "locha-p2p",
+                                "Dialing address: {}",
+                                to_dial
+                            );
+
                             if let Err(e) = Swarm::dial_addr(&mut swarm, to_dial.clone()) {
-                                error!("dial to {} failed: {}", to_dial, e);
+                                error!(
+                                    target: "locha-p2p",
+                                    "dial to {} failed: {}",
+                                    to_dial, e
+                                );
                             }
                         }
-                        ChatAction::SendMessage(message) => {
+                        RuntimeAction::SendMessage(message) => {
                             match swarm.publish(&topic, message.as_bytes()) {
                                 Ok(_) => (),
                                 Err(e) => {
@@ -363,14 +338,17 @@ impl Runtime {
     }
 
     async fn handle_swarm_event(
-        swarm_event: &SwarmEvent<GossipsubEvent, io::Error>,
+        swarm_event: &SwarmEvent<
+            NetworkEvent,
+            EitherError<io::Error, io::Error>,
+        >,
         events_handler: &mut dyn RuntimeEvents,
     ) {
-        trace!("new swarm event");
+        trace!(target: "locha-p2p", "new swarm event");
 
         match *swarm_event {
             SwarmEvent::Behaviour(ref behaviour) => {
-                Self::handle_gossipsub_event(behaviour, events_handler).await
+                Self::handle_behaviour_event(behaviour, events_handler).await
             }
             SwarmEvent::ConnectionEstablished {
                 ref peer_id,
@@ -400,8 +378,12 @@ impl Runtime {
                 ref local_addr,
                 ref send_back_addr,
             } => {
-                info!("Incoming connection on {}, with protocols for sending back {}",
-                      local_addr, send_back_addr);
+                info!(
+                    target: "locha-p2p",
+                    "Incoming connection on {}, with protocols for sending back {}",
+                    local_addr,
+                    send_back_addr
+                );
             }
             SwarmEvent::IncomingConnectionError {
                 ref local_addr,
@@ -409,13 +391,18 @@ impl Runtime {
                 ref error,
             } => {
                 error!(
-                    "Incoming connection error on {}: {}\n\
-                       Protocols for sending back {}",
+                    target: "locha-p2p",
+                    "Incoming connection error on {}: {} \
+                    Protocols for sending back {}",
                     local_addr, error, send_back_addr
                 );
             }
             SwarmEvent::BannedPeer { ref peer_id, .. } => {
-                info!("Peer {} is banned", peer_id);
+                info!(
+                    target: "locha-p2p",
+                    "Peer {} is banned",
+                    peer_id
+                );
             }
             SwarmEvent::UnreachableAddr {
                 ref peer_id,
@@ -424,9 +411,10 @@ impl Runtime {
                 ref attempts_remaining,
             } => {
                 warn!(
-                    "Address {} for peer {} is unreachable.\n\
-                      Attempt failed with error {}.\n\
-                      Attempts remaining: {}",
+                    target: "locha-p2p",
+                    "Address {} for peer {} is unreachable. \
+                    Attempt failed with error {}. \
+                    Attempts remaining: {}",
                     peer_id, address, error, attempts_remaining
                 );
             }
@@ -435,17 +423,27 @@ impl Runtime {
                 ref error,
             } => {
                 warn!(
-                    "Unknown peer address {} is unreachable.\n\
-                       Attempt failed with error {}",
+                    target: "locha-p2p",
+                    "Unknown peer address {} is unreachable. \
+                    Attempt failed with error {}",
                     address, error
                 );
             }
             SwarmEvent::NewListenAddr(ref address) => {
-                info!("Listening on new address {}", address);
+                info!(
+                    target: "locha-p2p",
+                    "Listening on new address {}",
+                    address
+                );
+
                 events_handler.on_new_listen_addr(address.clone())
             }
             SwarmEvent::ExpiredListenAddr(ref address) => {
-                info!("Listening address {} expired", address);
+                info!(
+                    target: "locha-p2p",
+                    "Listening address {} expired",
+                    address
+                );
             }
             SwarmEvent::ListenerClosed {
                 ref addresses,
@@ -459,42 +457,63 @@ impl Runtime {
                 match *reason {
                     Ok(_) => {
                         warn!(
-                            "Listener closed.\n\
+                            target: "locha-p2p",
+                            "Listener closed. \
                             Addresses affected {}",
                             affected,
                         );
                     }
                     Err(ref e) => {
                         warn!(
-                            "Listener closed. Reason {}.\n\
-                            Addresses affected:\n{}",
+                            target: "locha-p2p",
+                            "Listener closed. Reason {}. \
+                            Addresses affected: {}",
                             e, affected,
                         );
                     }
                 }
             }
             SwarmEvent::ListenerError { ref error } => {
-                warn!("Listener error {}.", error);
+                error!(target: "locha-p2p", "Listener error {}", error);
             }
             SwarmEvent::Dialing(ref peer_id) => {
-                info!("Dialing peer {}", peer_id);
+                debug!(target: "locha-p2p", "Dialing peer {}", peer_id);
             }
         }
     }
 
     /// Handle gossipsub events
-    async fn handle_gossipsub_event(
-        event: &GossipsubEvent,
+    async fn handle_behaviour_event(
+        event: &NetworkEvent,
         events_handler: &mut dyn RuntimeEvents,
     ) {
-        if let GossipsubEvent::Message(ref peer_id, ref id, ref message) =
-            *event
-        {
-            info!("Received message {}, from peer {}", id, peer_id);
+        match *event {
+            NetworkEvent::Gossipsub(ref gossip_ev) => {
+                if let GossipsubEvent::Message(
+                    ref peer_id,
+                    ref id,
+                    ref message,
+                ) = **gossip_ev
+                {
+                    debug!(
+                        target: "locha-p2p",
+                        "received message {}, from peer {}", id, peer_id
+                    );
 
-            let contents =
-                String::from_utf8_lossy(message.data.as_slice()).into_owned();
-            events_handler.on_new_message(contents);
+                    let contents =
+                        String::from_utf8_lossy(message.data.as_slice())
+                            .into_owned();
+                    events_handler.on_new_message(contents);
+                }
+            }
+            NetworkEvent::Discovery(ref disc_ev) => match *disc_ev {
+                DiscoveryEvent::Discovered(ref peer) => {
+                    info!(target: "locha-p2p", "discovered peer {}", peer);
+                }
+                DiscoveryEvent::UnroutablePeer(ref peer) => {
+                    info!(target: "locha-p2p", "unreachable peer {}", peer);
+                }
+            },
         }
     }
 }
@@ -514,8 +533,9 @@ fn log_connection_established(
     match endpoint {
         ConnectedPoint::Dialer { address } => {
             info!(
-                "Outbound connection to peer {} on address {} succeed.\n\
-                  Total number of established connections to peer are {}",
+                target: "locha-p2p",
+                "Outbound connection to peer {} on address {} succeed. \
+                Total number of established connections to peer are {}",
                 peer_id, address, num_established
             );
         }
@@ -523,10 +543,13 @@ fn log_connection_established(
             local_addr,
             send_back_addr,
         } => {
-            info!("Inbound connection to peer {} established on our address {} succeed.\n\
-                  The stack of protocols for sending back to this peer are {}.\n\
-                  Total number of established connections to this peer are {}",
-                  peer_id, local_addr, send_back_addr, num_established);
+            info!(
+                target: "locha-p2p",
+                "Inbound connection to peer {} established on our address {} succeed. \
+                The stack of protocols for sending back to this peer are {}. \
+                Total number of established connections to this peer are {}",
+                peer_id, local_addr, send_back_addr, num_established
+            );
         }
     }
 }
@@ -536,48 +559,61 @@ fn log_connection_closed(
     peer_id: &PeerId,
     endpoint: &ConnectedPoint,
     num_established: u32,
-    cause: &Option<ConnectionError<NodeHandlerWrapperError<io::Error>>>,
+    cause: &Option<
+        ConnectionError<
+            NodeHandlerWrapperError<EitherError<io::Error, io::Error>>,
+        >,
+    >,
 ) {
     match endpoint {
-        ConnectedPoint::Dialer { address } => {
-            match cause {
-                Some(cause) => {
-                    info!("Outbound connection to peer {} on address {} failed.\n\
-                          The cause of the close is {}.\n\
-                          The number of remaining connections to peer {}",
-                          peer_id, address, cause,
-                          num_established);
-                }
-                None => {
-                    info!("Outbound connection to peer {} on address {} failed.\n\
-                          The number of remaining connections to peer are {}",
-                          address, peer_id, num_established);
-                }
+        ConnectedPoint::Dialer { address } => match cause {
+            Some(cause) => {
+                info!(
+                    target: "locha-p2p",
+                    "Outbound connection to peer {} on address {} failed. \
+                    The cause of the close is {}. \
+                    The number of remaining connections to peer {}",
+                    peer_id, address, cause, num_established
+                );
             }
-        }
+            None => {
+                info!(
+                    target: "locha-p2p",
+                    "Outbound connection to peer {} on address {} failed. \
+                    The number of remaining connections to peer are {}",
+                    address, peer_id, num_established
+                );
+            }
+        },
         ConnectedPoint::Listener {
             local_addr,
             send_back_addr,
         } => match cause {
             Some(cause) => {
-                info!("Inbound connection from peer {} on our local address {} failed.\n\
-                          The cause of the close is {}.\n\
-                          The stack of protocols for sending back for this peer are {}.\n\
-                          The number of remaining connections to peer are {}",
-                          peer_id, local_addr, cause, send_back_addr, num_established);
+                info!(
+                    target: "locha-p2p",
+                    "Inbound connection from peer {} on our local address {} failed. \
+                    The cause of the close is {}. \
+                    The stack of protocols for sending back for this peer are {}. \
+                    The number of remaining connections to peer are {}",
+                    peer_id, local_addr, cause, send_back_addr, num_established
+                );
             }
             None => {
-                info!("Inbound connection from peer {} on our local address {} failed.\n\
-                          The stack of protocols for sending back for this peer are {}.\n\
-                          The number of remaining connections to peer are {}",
-                          peer_id, local_addr, send_back_addr, num_established);
+                info!(
+                    target: "locha-p2p",
+                    "Inbound connection from peer {} on our local address {} failed. \
+                    The stack of protocols for sending back for this peer are {}. \
+                    The number of remaining connections to peer are {}",
+                    peer_id, local_addr, send_back_addr, num_established
+                );
             }
         },
     }
 }
 
-/// Chat service action
-enum ChatAction {
+/// Runtime action
+enum RuntimeAction {
     /// Send a message
     SendMessage(String),
     /// Dial a peer

--- a/src/runtime/config.rs
+++ b/src/runtime/config.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! # Runtime configuration
+
 use crate::identity::Identity;
 use libp2p::Multiaddr;
 
@@ -21,4 +23,9 @@ pub struct RuntimeConfig {
     pub listen_addr: Multiaddr,
     pub channel_cap: usize,
     pub heartbeat_interval: u64,
+
+    pub use_mdns: bool,
+    pub allow_ipv4_private: bool,
+    pub allow_ipv6_link_local: bool,
+    pub allow_ipv6_ula: bool,
 }

--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! # Runtime errors
+
 use std::{error, fmt, io};
 
 use libp2p::TransportError;

--- a/src/runtime/events.rs
+++ b/src/runtime/events.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! # Runtime events
+
 use libp2p::Multiaddr;
 
 /// Chat service events

--- a/src/runtime/events.rs
+++ b/src/runtime/events.rs
@@ -13,17 +13,95 @@
 // limitations under the License.
 
 //! # Runtime events
+//!
+//! These are the network events reported during the operation of the node. The
+//! type must be `Send` because it will be used on the runtime task to report
+//! the events.
+//!
+//! Aditionally the wrapper [`RuntimeEventsLogger`] around [`RuntimeEvents`] is
+//! provided to log all events.
 
-use libp2p::Multiaddr;
+use libp2p::{Multiaddr, PeerId};
+
+use log::{debug, info};
 
 /// Chat service events
 pub trait RuntimeEvents: Send {
     /// New message received
     fn on_new_message(&mut self, message: String);
 
+    /// A peer has been discovered
+    ///
+    /// # Arguments
+    ///
+    /// - `peer` the now found peer.
+    /// - `addrs` addresses for the peer, ordered by priority.
+    fn on_peer_discovered(&mut self, peer: &PeerId, addrs: Vec<Multiaddr>);
+
+    /// Discovery process determined that the given peer is unroutable.
+    ///
+    /// # Arguments
+    ///
+    /// - `peer` the unroutable peer.
+    fn on_peer_unroutable(&mut self, peer: &PeerId);
+
     /// New listening address
     ///
     /// This informs that the Chat Service is listening on the provided
     /// Multiaddress.
-    fn on_new_listen_addr(&mut self, multiaddr: Multiaddr);
+    fn on_new_listen_addr(&mut self, address: &Multiaddr);
+}
+
+/// Small wrapper around [`RuntimeEvents`] that logs all events.
+pub struct RuntimeEventsLogger<T: RuntimeEvents>(T);
+
+impl<T> RuntimeEventsLogger<T>
+where
+    T: RuntimeEvents,
+{
+    /// Create a new [`RuntimeEventsLogger`]
+    pub fn new(events_handler: T) -> Self {
+        RuntimeEventsLogger(events_handler)
+    }
+}
+
+impl<T> RuntimeEvents for RuntimeEventsLogger<T>
+where
+    T: RuntimeEvents,
+{
+    fn on_new_message(&mut self, message: String) {
+        debug!("new message {}", message);
+
+        self.0.on_new_message(message)
+    }
+
+    fn on_peer_discovered(&mut self, peer: &PeerId, addrs: Vec<Multiaddr>) {
+        debug!(
+            target: "locha-p2p",
+            "discovered peer {}. Addresses: {:?}",
+            peer, addrs
+        );
+
+        self.0.on_peer_discovered(peer, addrs)
+    }
+
+    fn on_peer_unroutable(&mut self, peer: &PeerId) {
+        debug!(
+            target: "locha-p2p",
+            "unroutable peer {}",
+            peer
+        );
+
+        self.0.on_peer_unroutable(peer)
+    }
+
+    fn on_new_listen_addr(&mut self, address: &Multiaddr) {
+        info!(
+            target: "locha-p2p",
+            "Listening on new address {}",
+            address
+        );
+
+        self.0.on_new_listen_addr(address);
+    }
 }

--- a/src/runtime/sync_start_cond.rs
+++ b/src/runtime/sync_start_cond.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! # Synchronized start condition
+
 use std::sync::Arc;
 
 use parking_lot::{Condvar, Mutex};

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,0 +1,86 @@
+// Copyright 2020 Bitcoin Venezuela and Locha Mesh Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+use std::{error, io};
+
+use libp2p::core::muxing::{StreamMuxer, StreamMuxerBox};
+use libp2p::core::upgrade::{SelectUpgrade, Version};
+use libp2p::dns::DnsConfig;
+use libp2p::mplex::MplexConfig;
+use libp2p::noise;
+use libp2p::tcp::TcpConfig;
+use libp2p::websocket::WsConfig;
+use libp2p::yamux;
+use libp2p::Transport;
+
+use libp2p::identity::Keypair;
+use libp2p::PeerId;
+
+/// Builds the `Transport` used in Locha P2P
+pub fn build_transport(
+    keypair: &Keypair,
+) -> io::Result<
+    impl Transport<
+            Output = (
+                PeerId,
+                impl StreamMuxer<
+                        OutboundSubstream = impl Send,
+                        Substream = impl Send,
+                        Error = impl Into<io::Error>,
+                    > + Send
+                    + Sync,
+            ),
+            Error = impl error::Error + Send,
+            Listener = impl Send,
+            Dial = impl Send,
+            ListenerUpgrade = impl Send,
+        > + Clone,
+> {
+    // Create our low level TCP transport, and on top of it create a
+    // WebSockets transport. They can be used both at the same time.
+    let tcp = TcpConfig::new().nodelay(true);
+    let dns = DnsConfig::new(tcp)?;
+    let ws = WsConfig::new(dns.clone());
+    let transport = dns.or_transport(ws);
+
+    // Use the noise protocol to handle encryption and negotiation.
+    // Also we use yamux and mplex to multiplex connections to peers.
+    let noise_keys = noise::Keypair::<noise::X25519Spec>::new()
+        .into_authentic(keypair)
+        .expect("Signing noise static DH keypair failed.");
+
+    Ok(transport
+        .upgrade(Version::V1)
+        .authenticate(noise::NoiseConfig::xx(noise_keys).into_authenticated())
+        .multiplex(SelectUpgrade::new(
+            yamux::Config::default(),
+            MplexConfig::default(),
+        ))
+        .map(|(peer, muxer), _| (peer, StreamMuxerBox::new(muxer)))
+        .timeout(Duration::from_secs(20)))
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    #[test]
+    fn build_transport_ok() {
+        use libp2p::identity::Keypair;
+
+        let keypair = Keypair::generate_secp256k1();
+        build_transport(&keypair).expect("could not create transport!");
+    }
+}


### PR DESCRIPTION
Now we have a separate structure for the network behaviour which contains other behaviours such as the `Gossipsub` one and the `DiscoveryBehaviour`.

All events are returned through `NetworkEvent` which on runtime is used to dispatch events through `RuntimeEvents`.

Some arguments have been added for the locha-p2pd CLI to modify the behaviour of `DiscoveryBehaviour` which is still being tested, also Kademlia needs testing too.

Feel free to review the code.