### PR TITLE
Add miniupnpc bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ locha-p2pd/secret_key
 
 # Files from tests
 id.key
+
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0"
 
 [workspace]
-members = ["locha-p2pd"]
+members = ["locha-p2pd", "miniupnpc", "miniupnpc-sys"]
 
 [dependencies]
 async-std = { version = "1", features = ["unstable"] }
@@ -14,3 +14,5 @@ futures = "0.3"
 libp2p = "0.24"
 log = "0.4"
 parking_lot  = "0.11"
+miniupnpc = { version = "0.1", path = "miniupnpc" }
+void = "1"

--- a/locha-p2pd/src/main.rs
+++ b/locha-p2pd/src/main.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::net::Ipv4Addr;
 use std::path::Path;
 use std::thread;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -97,11 +98,13 @@ impl RuntimeEvents for EventsHandler {
         }
     }
 
-    fn on_new_listen_addr(&mut self, _multiaddr: &Multiaddr) {}
+    fn on_new_listen_addr(&mut self, _: &Multiaddr) {}
 
-    fn on_peer_discovered(&mut self, _peer: &PeerId, _addrs: Vec<Multiaddr>) {}
+    fn on_peer_discovered(&mut self, _: &PeerId, _: Vec<Multiaddr>) {}
 
-    fn on_peer_unroutable(&mut self, _peer: &PeerId) {}
+    fn on_peer_unroutable(&mut self, _: &PeerId) {}
+
+    fn on_external_ipv4_addr(&mut self, _: &Ipv4Addr) {}
 }
 
 #[derive(Deserialize, Serialize)]

--- a/miniupnpc-sys/Cargo.toml
+++ b/miniupnpc-sys/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "miniupnpc-sys"
+version = "0.1.0"
+authors = ["Locha Mesh Developers <contact@locha.io>"]
+edition = "2018"
+license = "Apache-2.0"
+build = "build.rs"
+
+[build-dependencies]
+git2 = "0.13"
+cc = "1"
+bindgen = "0.55"

--- a/miniupnpc-sys/build.rs
+++ b/miniupnpc-sys/build.rs
@@ -1,0 +1,133 @@
+// Copyright 2020 Bitcoin Venezuela and Locha Mesh Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::str::FromStr;
+
+// miniupnpd: VERSION 2.1
+const OID: &str = "582375b64f347d6ef1a4dc3478ff3678ea923f80";
+
+fn main() {
+    let out_dir = std::env::var("OUT_DIR")
+        .map(|s| PathBuf::from_str(s.as_str()).unwrap())
+        .expect("OUT_DIR not found!");
+
+    let repo_dir = out_dir.join("miniupnp");
+
+    let repo = match git2::Repository::clone(
+        "https://github.com/miniupnp/miniupnp",
+        &repo_dir,
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            if e.raw_class() == 3 && e.raw_code() == -4 {
+                git2::Repository::open(&repo_dir).unwrap()
+            } else {
+                panic!("could not clone repository: {}", e);
+            }
+        }
+    };
+
+    let oid = git2::Oid::from_str(OID).unwrap();
+    let commit = repo
+        .find_commit(oid)
+        .expect("could not find miniupnpc version on repository");
+
+    // Create new branch for repository pointing at the given commit
+    let _branch = repo.branch(OID, &commit, false);
+
+    // Checkout tree
+    let rev = format!("refs/heads/{}", OID);
+    let obj = repo
+        .revparse_single(rev.as_ref())
+        .expect("could not parse revision");
+    repo.checkout_tree(&obj, None)
+        .expect("could not checkout tree");
+    repo.set_head(rev.as_ref()).expect("could not set HEAD");
+
+    let miniupnpc_dir = repo_dir.join("miniupnpc");
+
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let target_family = std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
+
+    let update_res =
+        Command::new(miniupnpc_dir.join("updateminiupnpcstrings.sh"))
+            .current_dir(&miniupnpc_dir)
+            .output()
+            .unwrap();
+    assert!(update_res.status.success());
+
+    let mut build = cc::Build::new();
+
+    build.warnings(true);
+
+    build.file(miniupnpc_dir.join("miniwget.c"));
+    build.file(miniupnpc_dir.join("minixml.c"));
+    build.file(miniupnpc_dir.join("igd_desc_parse.c"));
+    build.file(miniupnpc_dir.join("minisoap.c"));
+    build.file(miniupnpc_dir.join("miniupnpc.c"));
+    build.file(miniupnpc_dir.join("upnpreplyparse.c"));
+    build.file(miniupnpc_dir.join("upnpcommands.c"));
+    build.file(miniupnpc_dir.join("upnperrors.c"));
+    build.file(miniupnpc_dir.join("connecthostport.c"));
+    build.file(miniupnpc_dir.join("portlistingparse.c"));
+    build.file(miniupnpc_dir.join("receivedata.c"));
+    build.file(miniupnpc_dir.join("upnpdev.c"));
+
+    if target_family == "unix" {
+        build
+            .file(miniupnpc_dir.join("minissdpc.c"))
+            .define("MINIUPNPC_SET_SOCKET_TIMEOUT", None)
+            .define("MINIUPNPC_GET_SRC_ADDR", None)
+            .define("_BSD_SOURCE", None)
+            .define("_DEFAULT_SOURCE", None);
+
+        if target_os == "netbsd" {
+            build.define("_NETBSD_SOURCE", None);
+        }
+
+        if target_os == "freebsd" || target_os == "macos" {
+            build.define("_XOPEN_SOURCE", "600");
+        }
+    } else if target_family == "windows" {
+        build.file(miniupnpc_dir.join("minissdpc.c"));
+        build.define("NDEBUG", None).define("_WIN32_WINNT", "0X501");
+        let compiler = build.get_compiler();
+        if compiler.is_like_gnu() || compiler.is_like_clang() {
+            build.flag("-lws2_32");
+            build.flag("-liphlpapi");
+            build.pic(true);
+        }
+
+        if compiler.is_like_msvc() {
+            build.define("_CRT_SECURE_NO_WARNINGS", None);
+        }
+    }
+
+    build.cargo_metadata(true);
+
+    build.compile("miniupnpc");
+
+    let bindings = bindgen::builder()
+        .header(miniupnpc_dir.join("miniupnpc.h").to_str().unwrap())
+        .header(miniupnpc_dir.join("upnpcommands.h").to_str().unwrap())
+        .header(miniupnpc_dir.join("upnperrors.h").to_str().unwrap())
+        .generate()
+        .expect("could not generate bindings");
+
+    bindings
+        .write_to_file(out_dir.join("bindings.rs"))
+        .expect("could not write bindings");
+}

--- a/miniupnpc-sys/src/lib.rs
+++ b/miniupnpc-sys/src/lib.rs
@@ -1,0 +1,27 @@
+// Copyright 2020 Bitcoin Venezuela and Locha Mesh Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # miniupnp-sys - MiniUPnP Raw Bindings
+//!
+//! These are the low level bindings for MiniUPnP.
+//!
+//! **Note:** The miniupnp is compiled from source code and linked
+//! statically, it doesn't use the installed library on your OS.
+//! Consider opening a PR is you consider it necessary.
+
+#![allow(non_snake_case)]
+#![doc(html_logo_url = "https://locha.io/i/128.png")]
+#![doc(html_favicon_url = "https://locha.io/i/128.png")]
+#![allow(clippy::redundant_static_lifetimes)]
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/miniupnpc/Cargo.toml
+++ b/miniupnpc/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "miniupnpc"
+version = "0.1.0"
+authors = ["Locha Mesh Developers <contact@locha.io>"]
+edition = "2018"
+license = "Apache-2.0"
+
+[dependencies]
+miniupnpc-sys = { version = "0.1", path = "../miniupnpc-sys" }
+
+[dev-dependencies]
+clap = "2"

--- a/miniupnpc/examples/upnpc.rs
+++ b/miniupnpc/examples/upnpc.rs
@@ -1,0 +1,115 @@
+// Copyright 2020 Bitcoin Venezuela and Locha Mesh Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+use std::time::Duration;
+
+use clap::{crate_authors, crate_version, value_t, App, Arg};
+
+fn main() {
+    let matches = App::new("upnpc")
+        .version(crate_version!())
+        .author(crate_authors!())
+        .about("UPNP client tool")
+        .arg(
+            Arg::with_name("version")
+                .long("version")
+                .takes_value(false)
+                .help("Print version information"))
+        .arg(
+            Arg::with_name("ipv6")
+                .long("ipv6")
+                .short("6")
+                .takes_value(false)
+                .help("Use IPv6"),
+        )
+        .arg(
+            Arg::with_name("ttl")
+                .long("ttl")
+                .takes_value(true)
+                .default_value("2")
+                .help("Sets the value of the socket option `IP_MULTICAST_TTL`/`IPV6_MULTICAST_HOPS` depending on the protocol used."),
+        )
+        .get_matches();
+
+    if matches.is_present("version") {
+        println!("unpnc {}\n", crate_version!());
+        println!("miniupnpc API version: {}", miniupnpc::api_version());
+        println!("miniupnpc version: {}", miniupnpc::version());
+        return;
+    }
+
+    let devices = miniupnpc::discover(
+        Duration::from_secs(2),
+        None,
+        None,
+        miniupnpc::LocalPort::Any,
+        matches.is_present("ipv6"),
+        value_t!(matches.value_of("ttl"), u8).unwrap_or_else(|e| e.exit()),
+    )
+    .unwrap();
+
+    println!("List of UPnP devices found on the network:");
+    for device in devices.iter() {
+        println!("desc: {}", device.desc_url());
+        println!("scope id: {}", device.scope_id());
+    }
+
+    let igd = match devices.get_valid_igd() {
+        Some(v) => v,
+        None => {
+            println!("No UPnP devices found");
+            return;
+        }
+    };
+
+    if igd.data.is_some() {
+        println!("Found Internet Gateway Device");
+    } else {
+        println!("Internet Gateway Device not found");
+        return;
+    }
+
+    let igd_data = igd.data.unwrap();
+
+    display_infos(&igd.urls, &igd_data)
+}
+
+fn display_infos(urls: &miniupnpc::Urls, igd_data: &miniupnpc::IgdData) {
+    let type_info = miniupnpc::commands::get_connection_type_info(
+        urls.control_url(),
+        igd_data.first().service_type(),
+    )
+    .unwrap();
+
+    let status_info = miniupnpc::commands::get_status_info(
+        urls.control_url(),
+        igd_data.first().service_type(),
+    )
+    .unwrap();
+
+    let ipaddr = miniupnpc::commands::get_external_ip_address(
+        urls.control_url(),
+        igd_data.first().service_type(),
+    )
+    .unwrap();
+
+    println!("Connection type: {}", type_info);
+    println!(
+        "Status: {}, uptime={}s, LastConnectionError=\"{}\"",
+        status_info.status,
+        status_info.uptime.as_secs(),
+        status_info.lastconnerror
+    );
+    println!("External IPv4 address: {}", ipaddr);
+}

--- a/miniupnpc/src/lib.rs
+++ b/miniupnpc/src/lib.rs
@@ -1,0 +1,549 @@
+// Copyright 2020 Bitcoin Venezuela and Locha Mesh Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # MiniUPnP
+//!
+//! This crate contains safe bindings to the [miniupnpc] library.
+//!
+//! >"UPnP is a set of networking protocols that allows networked devices
+//! to seamlessy discover each other's presence on the network."
+//!
+//! See also: [Universal Plug and Play](https://en.wikipedia.org/wiki/Universal_Plug_and_Play)
+//!
+//! [miniupnpc]: https://github.com/miniupnp/miniupnp
+
+#![doc(html_logo_url = "https://locha.io/i/128.png")]
+#![doc(html_favicon_url = "https://locha.io/i/128.png")]
+
+use std::{error, fmt, ptr};
+
+use std::borrow::Cow;
+use std::ffi::{CStr, CString};
+use std::marker::PhantomData;
+use std::mem::MaybeUninit;
+use std::os::raw::{c_char, c_int, c_uchar};
+
+use std::time::Duration;
+
+/// MiniUPnP API version
+pub const fn api_version() -> u32 {
+    miniupnpc_sys::MINIUPNPC_API_VERSION
+}
+
+/// MiniUPnP version
+pub fn version() -> &'static str {
+    CStr::from_bytes_with_nul(miniupnpc_sys::MINIUPNPC_VERSION)
+        .unwrap()
+        .to_str()
+        .unwrap()
+}
+
+/// MiniUPnP library errors.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct Error(c_int);
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let str: &'static CStr =
+            unsafe { CStr::from_ptr(miniupnpc_sys::strupnperror(self.0)) };
+        write!(f, "{}", str.to_string_lossy())
+    }
+}
+
+impl error::Error for Error {}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum LocalPort {
+    /// The OS assigns the source port
+    Any,
+    /// Uses the same destination port (1900).
+    Same,
+    /// Other local port.
+    Other(u16),
+}
+
+/// Discover uPnP devices.
+///
+/// This function blocks until all devices have been discovered.
+/// `delay` impacts the waiting time.
+///
+/// # Arguments
+///
+/// - `delay`: Maximum delay for a device to respond.
+/// - `multicast_if`: Multicast network interface to use if provided.
+/// - `minissdp_sock`: Minissdpd sock if provided.
+/// - `localport`: Local port (source) to use.
+/// - `ipv6`: use IPv6.
+/// - `ttl`: sets the value of `IP_MULTICAST_TTL` or `IPV6_MULTICAST_HOPS`
+/// respectively depending on which protocol is used. Default value is `2`.
+///
+/// # Errors
+///
+/// This function might return an error on Out-of-memory or when the socket
+/// fails.
+pub fn discover(
+    delay: Duration,
+    multicast_if: Option<&str>,
+    minissdp_sock: Option<&str>,
+    localport: LocalPort,
+    ipv6: bool,
+    ttl: u8,
+) -> Result<DeviceList, Error> {
+    let delay = delay.as_millis() as c_int;
+    let multicastif = multicast_if.map(|v| CString::new(v).unwrap());
+    let minissdpsock = minissdp_sock.map(|v| CString::new(v).unwrap());
+    let localport: c_int = match localport {
+        LocalPort::Any => miniupnpc_sys::UPNP_LOCAL_PORT_ANY as c_int,
+        LocalPort::Same => miniupnpc_sys::UPNP_LOCAL_PORT_SAME as c_int,
+        LocalPort::Other(v) => v as c_int,
+    };
+    let ipv6: c_int = if ipv6 { 1 } else { 0 };
+    let ttl: c_uchar = ttl as c_uchar;
+
+    let mut error: c_int = 0;
+    let ptr = unsafe {
+        miniupnpc_sys::upnpDiscover(
+            delay,
+            if let Some(multicastif) = multicastif {
+                multicastif.as_c_str().as_ptr()
+            } else {
+                ptr::null()
+            },
+            if let Some(minissdpsock) = minissdpsock {
+                minissdpsock.as_c_str().as_ptr()
+            } else {
+                ptr::null()
+            },
+            localport,
+            ipv6,
+            ttl,
+            (&mut error) as *mut c_int,
+        )
+    };
+
+    if ptr.is_null() && error != miniupnpc_sys::UPNPDISCOVER_SUCCESS as c_int {
+        return Err(Error(error));
+    }
+
+    Ok(DeviceList(ptr))
+}
+
+/// uPnP discovered devices list
+#[derive(Debug)]
+pub struct DeviceList(*mut miniupnpc_sys::UPNPDev);
+
+impl DeviceList {
+    /// Returns an iterator over the device list
+    ///
+    /// If the list is empty the iterator will return `None` on
+    /// first iteration.
+    pub fn iter(&self) -> DeviceListIter<'_> {
+        DeviceListIter {
+            current: self.0,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Is the device list empty?
+    pub fn is_empty(&self) -> bool {
+        self.0.is_null()
+    }
+
+    /// Get valid IGD from the device list
+    pub fn get_valid_igd(&self) -> Option<ValidIgd> {
+        unsafe {
+            let mut urls: miniupnpc_sys::UPNPUrls =
+                MaybeUninit::zeroed().assume_init();
+            let mut data: miniupnpc_sys::IGDdatas =
+                MaybeUninit::zeroed().assume_init();
+            let mut lanaddr: [u8; 64] = [0; 64];
+
+            let ret = miniupnpc_sys::UPNP_GetValidIGD(
+                self.0,
+                (&mut urls) as *mut miniupnpc_sys::UPNPUrls,
+                (&mut data) as *mut miniupnpc_sys::IGDdatas,
+                lanaddr.as_mut_ptr() as *mut c_char,
+                lanaddr.len() as c_int,
+            );
+
+            let (is_igd, is_connected) = match ret {
+                // No IGD found
+                0 => return None,
+                // Valid IGD found
+                1 => (true, true),
+                // Valid IGD found but not connected
+                2 => (true, false),
+                // UPnP device found, but was not IGD
+                3 => (false, false),
+                _ => unreachable!(),
+            };
+
+            let lan_address = CStr::from_ptr(lanaddr.as_ptr() as *const c_char)
+                .to_string_lossy()
+                .into_owned();
+
+            Some(ValidIgd {
+                urls: Urls(urls),
+                data: if is_igd { Some(IgdData(data)) } else { None },
+                lan_address,
+                connected: is_connected,
+            })
+        }
+    }
+}
+
+impl Drop for DeviceList {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            unsafe { miniupnpc_sys::freeUPNPDevlist(self.0) }
+            self.0 = ptr::null_mut();
+        }
+    }
+}
+
+unsafe impl Send for DeviceList {}
+
+/// Iterator over a [`DeviceList`]
+#[derive(Debug)]
+pub struct DeviceListIter<'list> {
+    current: *mut miniupnpc_sys::UPNPDev,
+    _marker: PhantomData<&'list mut miniupnpc_sys::UPNPDev>,
+}
+
+impl<'list> Iterator for DeviceListIter<'list> {
+    type Item = Device<'list>;
+
+    fn next(&mut self) -> Option<Device<'list>> {
+        if self.current.is_null() {
+            return None;
+        }
+
+        let current = self.current;
+        self.current = unsafe { (*current).pNext };
+        Some(Device(current, PhantomData))
+    }
+}
+
+/// Single uPnP device.
+pub struct Device<'list>(
+    *mut miniupnpc_sys::UPNPDev,
+    PhantomData<&'list mut miniupnpc_sys::UPNPDev>,
+);
+
+impl<'list> Device<'list> {
+    /// Description URL
+    pub fn desc_url(&self) -> Cow<'list, str> {
+        unsafe {
+            let cstr = CStr::from_ptr((*self.0).descURL);
+            cstr.to_string_lossy()
+        }
+    }
+
+    /// Returns the scope ID associated with this device.
+    pub fn scope_id(&self) -> u32 {
+        let sid = unsafe { (*self.0).scope_id };
+        sid as u32
+    }
+}
+
+unsafe impl<'list> Send for Device<'list> {}
+
+/// Information about a valid IGD
+#[derive(Debug)]
+pub struct ValidIgd {
+    pub urls: Urls,
+    pub data: Option<IgdData>,
+    pub lan_address: String,
+    pub connected: bool,
+}
+
+/// UPnP IGD device URLs
+pub struct Urls(miniupnpc_sys::UPNPUrls);
+
+impl Urls {
+    /// Control URL of WANIPConnection
+    pub fn control_url(&self) -> Cow<'_, str> {
+        unsafe { CStr::from_ptr(self.0.controlURL).to_string_lossy() }
+    }
+
+    /// URL of the description of WANIPConnection
+    pub fn ipcon_desc_url(&self) -> Cow<'_, str> {
+        unsafe { CStr::from_ptr(self.0.ipcondescURL).to_string_lossy() }
+    }
+
+    /// Control URL of the WANCommonInterfaceConfig
+    pub fn control_url_cif(&self) -> Cow<'_, str> {
+        unsafe { CStr::from_ptr(self.0.controlURL_CIF).to_string_lossy() }
+    }
+
+    /// Control URL of the WANIPv6FirewallControl
+    pub fn control_url_6fc(&self) -> Cow<'_, str> {
+        unsafe { CStr::from_ptr(self.0.controlURL_6FC).to_string_lossy() }
+    }
+
+    /// Root description URL
+    pub fn root_desc_url(&self) -> Cow<'_, str> {
+        unsafe { CStr::from_ptr(self.0.rootdescURL).to_string_lossy() }
+    }
+}
+
+impl Drop for Urls {
+    fn drop(&mut self) {
+        unsafe {
+            miniupnpc_sys::FreeUPNPUrls(
+                (&mut self.0) as *mut miniupnpc_sys::UPNPUrls,
+            );
+        }
+    }
+}
+
+impl fmt::Debug for Urls {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Urls")
+            .field("controlURL", &self.control_url())
+            .field("ipcondescURL", &self.ipcon_desc_url())
+            .field("controlURL_CIF", &self.control_url_cif())
+            .field("controlURL_6FC", &self.control_url_6fc())
+            .finish()
+    }
+}
+
+unsafe impl Send for Urls {}
+unsafe impl Sync for Urls {}
+
+/// IGD data
+pub struct IgdData(miniupnpc_sys::IGDdatas);
+
+impl IgdData {
+    // TODO: decipher the meaning of this :-(
+    pub fn cur_elt_name(&self) -> Cow<'_, str> {
+        unsafe { CStr::from_ptr(self.0.cureltname.as_ptr()).to_string_lossy() }
+    }
+
+    pub fn url_base(&self) -> Cow<'_, str> {
+        unsafe { CStr::from_ptr(self.0.urlbase.as_ptr()).to_string_lossy() }
+    }
+
+    pub fn presentation_url(&self) -> Cow<'_, str> {
+        unsafe {
+            CStr::from_ptr(self.0.presentationurl.as_ptr()).to_string_lossy()
+        }
+    }
+
+    pub fn level(&self) -> i32 {
+        self.0.level as i32
+    }
+
+    pub fn cif(&self) -> IgdService<'_> {
+        IgdService(&self.0.CIF)
+    }
+
+    pub fn first(&self) -> IgdService<'_> {
+        IgdService(&self.0.first)
+    }
+
+    pub fn second(&self) -> IgdService<'_> {
+        IgdService(&self.0.second)
+    }
+
+    pub fn ipv6_fc(&self) -> IgdService<'_> {
+        IgdService(&self.0.IPv6FC)
+    }
+
+    pub fn tmp(&self) -> IgdService<'_> {
+        IgdService(&self.0.tmp)
+    }
+}
+
+impl fmt::Debug for IgdData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("IgdData")
+            .field("cureltname", &self.cur_elt_name())
+            .field("urlbase", &self.url_base())
+            .field("presentationurl", &self.presentation_url())
+            .field("level", &self.level())
+            .field("CIF", &self.cif())
+            .field("first", &self.first())
+            .field("second", &self.second())
+            .field("IPv6FC", &self.ipv6_fc())
+            .field("tmp", &self.tmp())
+            .finish()
+    }
+}
+
+unsafe impl Send for IgdData {}
+/// IGD service information
+pub struct IgdService<'a>(&'a miniupnpc_sys::IGDdatas_service);
+
+impl<'a> IgdService<'a> {
+    pub fn control_url(&self) -> Cow<'a, str> {
+        unsafe { CStr::from_ptr(self.0.controlurl.as_ptr()).to_string_lossy() }
+    }
+
+    pub fn event_sub_url(&self) -> Cow<'a, str> {
+        unsafe { CStr::from_ptr(self.0.eventsuburl.as_ptr()).to_string_lossy() }
+    }
+
+    pub fn scpd_url(&self) -> Cow<'a, str> {
+        unsafe { CStr::from_ptr(self.0.scpdurl.as_ptr()).to_string_lossy() }
+    }
+
+    pub fn service_type(&self) -> Cow<'a, str> {
+        unsafe { CStr::from_ptr(self.0.servicetype.as_ptr()).to_string_lossy() }
+    }
+}
+
+impl<'a> fmt::Debug for IgdService<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("IgdService")
+            .field("controlurl", &self.control_url())
+            .field("eventsuburl", &self.event_sub_url())
+            .field("scpdurl", &self.scpd_url())
+            .field("servicetype", &self.service_type())
+            .finish()
+    }
+}
+
+/// # UPnP Commands
+pub mod commands {
+    use std::ffi::{CStr, CString};
+    use std::os::raw::{c_char, c_int, c_uint};
+
+    use std::net::Ipv4Addr;
+    use std::str::FromStr;
+    use std::time::Duration;
+
+    use crate::Error;
+
+    /// Get connection type information.
+    #[allow(non_snake_case)]
+    pub fn get_connection_type_info<C, S>(
+        control_url: C,
+        service_type: S,
+    ) -> Result<String, Error>
+    where
+        C: AsRef<str>,
+        S: AsRef<str>,
+    {
+        let controlURL = CString::new(control_url.as_ref()).unwrap();
+        let servicetype = CString::new(service_type.as_ref()).unwrap();
+        let mut connectionType: [c_char; 64] = [0; 64];
+
+        unsafe {
+            let ret = miniupnpc_sys::UPNP_GetConnectionTypeInfo(
+                controlURL.as_c_str().as_ptr(),
+                servicetype.as_c_str().as_ptr(),
+                connectionType.as_mut_ptr(),
+            );
+
+            if ret != miniupnpc_sys::UPNPCOMMAND_SUCCESS as c_int {
+                return Err(Error(ret));
+            }
+
+            Ok(CStr::from_ptr(connectionType.as_ptr())
+                .to_string_lossy()
+                .into_owned())
+        }
+    }
+
+    /// Get External IPv4 address
+    ///
+    /// This asks for an IGD device for our external IPv4 address if we are
+    /// behind a NATed device/router.
+    ///
+    /// # Arguments
+    ///
+    /// - `control_url`: IGD control URL.
+    /// - `service_type`: IGD service type.
+    #[allow(non_snake_case)]
+    pub fn get_external_ip_address<C, S>(
+        control_url: C,
+        service_type: S,
+    ) -> Result<Ipv4Addr, Error>
+    where
+        C: AsRef<str>,
+        S: AsRef<str>,
+    {
+        let controlURL = CString::new(control_url.as_ref()).unwrap();
+        let servicetype = CString::new(service_type.as_ref()).unwrap();
+        let mut extIpAdd = [0u8; 40];
+
+        let ipaddr = unsafe {
+            let ret = miniupnpc_sys::UPNP_GetExternalIPAddress(
+                controlURL.as_c_str().as_ptr(),
+                servicetype.as_c_str().as_ptr(),
+                extIpAdd.as_mut_ptr() as *mut c_char,
+            );
+
+            if ret != miniupnpc_sys::UPNPCOMMAND_SUCCESS as c_int {
+                return Err(Error(ret));
+            }
+
+            CStr::from_ptr(extIpAdd.as_ptr() as *const c_char)
+                .to_string_lossy()
+                .into_owned()
+        };
+
+        Ok(Ipv4Addr::from_str(ipaddr.as_str()).unwrap())
+    }
+
+    /// UPnP status information
+    #[derive(Debug, Clone, Eq, PartialEq)]
+    pub struct StatusInfo {
+        pub status: String,
+        pub uptime: Duration,
+        pub lastconnerror: String,
+    }
+
+    /// Get status info
+    #[allow(non_snake_case)]
+    pub fn get_status_info<C, S>(
+        control_url: C,
+        service_type: S,
+    ) -> Result<StatusInfo, Error>
+    where
+        C: AsRef<str>,
+        S: AsRef<str>,
+    {
+        let controlURL = CString::new(control_url.as_ref()).unwrap();
+        let servicetype = CString::new(service_type.as_ref()).unwrap();
+        let mut status: [c_char; 64] = [0; 64];
+        let mut uptime: c_uint = 0;
+        let mut lastconnerr: [c_char; 64] = [0; 64];
+
+        unsafe {
+            let ret = miniupnpc_sys::UPNP_GetStatusInfo(
+                controlURL.as_c_str().as_ptr(),
+                servicetype.as_c_str().as_ptr(),
+                status.as_mut_ptr(),
+                (&mut uptime) as *mut c_uint,
+                lastconnerr.as_mut_ptr(),
+            );
+
+            if ret != miniupnpc_sys::UPNPCOMMAND_SUCCESS as c_int {
+                return Err(Error(ret));
+            }
+
+            Ok(StatusInfo {
+                status: CStr::from_ptr(status.as_ptr())
+                    .to_string_lossy()
+                    .into_owned(),
+                uptime: Duration::from_secs(uptime as u64),
+                lastconnerror: CStr::from_ptr(status.as_ptr())
+                    .to_string_lossy()
+                    .into_owned(),
+            })
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub mod gossip;
 pub mod identity;
 pub mod network;
 pub mod runtime;
+pub mod upnp;
 
 pub use libp2p::Multiaddr;
 pub use libp2p::PeerId;

--- a/src/network.rs
+++ b/src/network.rs
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::time::Duration;
+
 use libp2p::NetworkBehaviour;
 
 use crate::discovery::{DiscoveryBehaviour, DiscoveryEvent};
 use crate::gossip::{Gossipsub, GossipsubEvent, PublishError, Topic};
+use crate::upnp::{Upnp, UpnpEvent};
 
 use crate::identity::Identity;
 
@@ -25,6 +28,7 @@ use crate::identity::Identity;
 pub struct Network {
     discovery: DiscoveryBehaviour,
     gossip: Gossipsub,
+    upnp: Upnp,
 }
 
 impl Network {
@@ -35,6 +39,7 @@ impl Network {
         Network {
             discovery,
             gossip: crate::gossip::new(identity),
+            upnp: Upnp::new(Duration::from_secs(30)),
         }
     }
 
@@ -55,6 +60,7 @@ impl Network {
 pub enum NetworkEvent {
     Discovery(DiscoveryEvent),
     Gossipsub(Box<GossipsubEvent>),
+    Upnp(UpnpEvent),
 }
 
 impl From<DiscoveryEvent> for NetworkEvent {
@@ -66,5 +72,11 @@ impl From<DiscoveryEvent> for NetworkEvent {
 impl From<GossipsubEvent> for NetworkEvent {
     fn from(event: GossipsubEvent) -> NetworkEvent {
         NetworkEvent::Gossipsub(Box::new(event))
+    }
+}
+
+impl From<UpnpEvent> for NetworkEvent {
+    fn from(event: UpnpEvent) -> NetworkEvent {
+        NetworkEvent::Upnp(event)
     }
 }

--- a/src/runtime/events.rs
+++ b/src/runtime/events.rs
@@ -21,6 +21,8 @@
 //! Aditionally the wrapper [`RuntimeEventsLogger`] around [`RuntimeEvents`] is
 //! provided to log all events.
 
+use std::net::Ipv4Addr;
+
 use libp2p::{Multiaddr, PeerId};
 
 use log::{debug, info};
@@ -50,6 +52,11 @@ pub trait RuntimeEvents: Send {
     /// This informs that the Chat Service is listening on the provided
     /// Multiaddress.
     fn on_new_listen_addr(&mut self, address: &Multiaddr);
+
+    /// New external address
+    ///
+    /// This informs that our external IPv4 address has been found.
+    fn on_external_ipv4_addr(&mut self, address: &Ipv4Addr);
 }
 
 /// Small wrapper around [`RuntimeEvents`] that logs all events.
@@ -103,5 +110,15 @@ where
         );
 
         self.0.on_new_listen_addr(address);
+    }
+
+    fn on_external_ipv4_addr(&mut self, address: &Ipv4Addr) {
+        info!(
+            target: "locha-p2p",
+            "External IPv4 adddress found: {}",
+            address
+        );
+
+        self.0.on_external_ipv4_addr(address);
     }
 }

--- a/src/upnp.rs
+++ b/src/upnp.rs
@@ -1,0 +1,174 @@
+// Copyright 2020 Bitcoin Venezuela and Locha Mesh Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # UPnP network behaviour
+//!
+//! This network behaviour is in charge of finding UPnP Internet Gateway
+//! Devices to ask these devices about our Internet connection status and
+//! our IPv4 external IP address if we have one.
+//!
+//! TODO: handle UPnP port mapping
+
+use std::net::Ipv4Addr;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use async_std::pin::Pin;
+use async_std::sync::{channel, Receiver};
+use async_std::task;
+
+use futures::stream::Stream;
+
+use libp2p::core::connection::ConnectionId;
+use libp2p::swarm::protocols_handler::DummyProtocolsHandler;
+use libp2p::swarm::{KeepAlive, PollParameters};
+use libp2p::swarm::{NetworkBehaviour, NetworkBehaviourAction};
+use libp2p::{Multiaddr, PeerId};
+
+use void::Void;
+
+use log::{debug, error, warn};
+
+#[derive(Debug)]
+pub struct Upnp {
+    worker: task::JoinHandle<()>,
+    rx: Receiver<UpnpEvent>,
+}
+
+impl Upnp {
+    pub fn new(tick: Duration) -> Upnp {
+        let (tx, rx) = channel::<UpnpEvent>(10);
+
+        Upnp {
+            worker: task::spawn(async move {
+                let sleep_time = tick;
+
+                loop {
+                    let igd = match miniupnpc::discover(
+                        Duration::from_secs(2),
+                        None,
+                        None,
+                        miniupnpc::LocalPort::Any,
+                        false,
+                        2,
+                    )
+                    .map(|list| list.get_valid_igd())
+                    {
+                        Ok(v) if v.is_some() => {
+                            let igd = v.unwrap();
+                            if igd.data.is_none() {
+                                debug!(
+                                    target: "locha-p2p",
+                                    "found UPnP device(s), but aren't gateways: {:?}",
+                                    igd
+                                );
+                                task::sleep(sleep_time).await;
+                                continue;
+                            }
+                            igd
+                        }
+                        Ok(_) => {
+                            debug!(target: "locha-p2p", "no IGD found");
+                            task::sleep(sleep_time).await;
+                            continue;
+                        }
+                        Err(e) => {
+                            warn!(
+                                target: "locha-p2p",
+                                "could not get UPnP IGD device: {}",
+                                e
+                            );
+                            task::sleep(sleep_time).await;
+                            continue;
+                        }
+                    };
+
+                    let igd_data = igd.data.unwrap();
+                    match miniupnpc::commands::get_external_ip_address(
+                        igd.urls.control_url(),
+                        igd_data.first().service_type(),
+                    ) {
+                        Ok(ipv4) => {
+                            debug!(
+                                target: "locha-p2p",
+                                "found external IPv4 address: {}",
+                                ipv4
+                            );
+                            tx.send(UpnpEvent::ExternalIpv4Address(ipv4)).await;
+                        }
+                        Err(e) => {
+                            warn!(
+                                target: "locha-p2p",
+                                "External IPv4 address not found: {}",
+                                e
+                            );
+                        }
+                    };
+
+                    task::sleep(sleep_time).await;
+                }
+            }),
+            rx,
+        }
+    }
+}
+
+/// UPnP event
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum UpnpEvent {
+    /// Found our external IPv4 address
+    ExternalIpv4Address(Ipv4Addr),
+}
+
+impl NetworkBehaviour for Upnp {
+    type ProtocolsHandler = DummyProtocolsHandler;
+    type OutEvent = UpnpEvent;
+
+    fn new_handler(&mut self) -> DummyProtocolsHandler {
+        DummyProtocolsHandler {
+            keep_alive: KeepAlive::No,
+        }
+    }
+
+    fn addresses_of_peer(&mut self, _: &PeerId) -> Vec<Multiaddr> {
+        vec![]
+    }
+
+    fn inject_connected(&mut self, _: &PeerId) {}
+    fn inject_disconnected(&mut self, _: &PeerId) {}
+
+    fn inject_event(&mut self, _: PeerId, _: ConnectionId, event: Void) {
+        match event {}
+    }
+
+    fn poll(
+        &mut self,
+        cx: &mut Context<'_>,
+        _: &mut impl PollParameters,
+    ) -> Poll<NetworkBehaviourAction<Void, UpnpEvent>> {
+        match Pin::new(&mut self.rx).poll_next(cx) {
+            Poll::Ready(Some(ev)) => {
+                Poll::Ready(NetworkBehaviourAction::GenerateEvent(ev))
+            }
+            Poll::Ready(None) => {
+                error!(
+                    target: "locha-p2p",
+                    "UPnP worker thread has dropped channel TX"
+                );
+                Poll::Pending
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}


### PR DESCRIPTION
This adds miniupnpc bindings for Rust, this is still WIP. The build script for miniupnpc-sys downloads the source code from github and checks out the required version, it also automatically generates the bindings from the source code.

A safe wrapper for working with miniupnpc is on the works to make the bindings usable from safe Rust.