### PR TITLE
Resolve external addresses using UPnP

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ log = "0.4"
 parking_lot  = "0.11"
 miniupnpc = { version = "0.1", path = "miniupnpc" }
 void = "1"
+wasm-timer = "0.2"

--- a/locha-p2pd/src/main.rs
+++ b/locha-p2pd/src/main.rs
@@ -159,7 +159,7 @@ async fn main() {
         heartbeat_interval: 10,
         listen_addr: arguments.listen_addr,
 
-        discovery: discovery,
+        discovery,
     };
 
     let (sender, receiver) = channel::<Message>(10);
@@ -169,24 +169,27 @@ async fn main() {
     };
 
     let (upnp, upnp_task) = Upnp::new();
+    task::spawn(upnp_task);
+
+    if let Some(ip) = upnp.get_external_ip_address().await.unwrap() {
+        info!(target: "locha-p2p", "UPnP: ExternalIPAddress={}", ip);
+    }
+
     let (runtime, runtime_task) = Runtime::new(
         config,
         Box::new(RuntimeEventsLogger::new(events_handler)),
-        Some(upnp.clone()),
     )
     .unwrap();
 
-    task::spawn(upnp_task);
     task::spawn(runtime_task);
-
-    if let Some(ip) = upnp.get_external_ip_address().await {
-        info!(target: "locha-p2p", "UPnP: ExternalIPAddress={}", ip);
-    }
 
     // Reach out to another node if specified
     for to_dial in arguments.dials {
         runtime.dial(to_dial).await
     }
+
+    // Enable UPnP port mapping
+    runtime.enable_upnp(upnp).await.unwrap();
 
     let input = io::stdin();
     let channel = receiver;

--- a/locha-p2pd/src/main.rs
+++ b/locha-p2pd/src/main.rs
@@ -178,6 +178,7 @@ async fn main() {
     let (runtime, runtime_task) = Runtime::new(
         config,
         Box::new(RuntimeEventsLogger::new(events_handler)),
+        true,
     )
     .unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,11 +51,13 @@ pub type Swarm = libp2p::Swarm<self::network::Network>;
 pub fn build_swarm(
     identity: &self::identity::Identity,
     discovery_config: self::discovery::DiscoveryConfig,
+    upnp: bool,
 ) -> Result<Swarm, std::io::Error> {
     let transport = build_transport(&identity.keypair())?;
     let discovery =
         self::discovery::DiscoveryBehaviour::with_config(discovery_config);
-    let behaviour = self::network::Network::with_discovery(identity, discovery);
+    let behaviour =
+        self::network::Network::with_discovery(identity, discovery, upnp);
 
     Ok(Swarm::new(transport, behaviour, identity.id()))
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -73,7 +73,10 @@ pub mod config;
 pub mod error;
 pub mod events;
 
-use futures::channel::mpsc::{channel, Receiver, Sender};
+use futures::channel::mpsc::{channel, Receiver, SendError, Sender};
+use futures::channel::oneshot::{
+    channel as oneshot_channel, Sender as OneshotSender,
+};
 use futures::{Future, FutureExt, SinkExt, StreamExt};
 
 use libp2p::swarm::{NetworkBehaviour, SwarmEvent};
@@ -112,7 +115,6 @@ impl Runtime {
     pub fn new(
         config: RuntimeConfig,
         events_handler: Box<dyn RuntimeEvents>,
-        upnp: Option<Upnp>,
     ) -> Result<(Runtime, impl Future<Output = ()> + Send + 'static), Error>
     {
         let mut swarm =
@@ -136,7 +138,7 @@ impl Runtime {
 
         let (tx, rx) = channel(config.channel_cap);
 
-        Ok((Runtime { tx }, task(swarm, events_handler, topic, rx, upnp)))
+        Ok((Runtime { tx }, task(swarm, events_handler, topic, rx)))
     }
 
     /// Stop the runtime.
@@ -168,16 +170,28 @@ impl Runtime {
             .await
             .unwrap()
     }
+
+    pub async fn enable_upnp(&self, upnp: Upnp) -> Result<(), &'static str> {
+        trace!(target: "locha-p2p", "enabling UPnP");
+
+        let (tx, rx) = oneshot_channel::<Result<(), &'static str>>();
+
+        self.tx
+            .clone()
+            .send(RuntimeAction::EnableUpnp(upnp, tx))
+            .await
+            .unwrap();
+
+        rx.await.unwrap()
+    }
 }
 
 /// Runtime action
 enum RuntimeAction {
-    /// Send a message
-    SendMessage(String),
-    /// Dial a peer
-    Dial(Multiaddr),
-    /// Stop the chat service
     Stop,
+    Dial(Multiaddr),
+    SendMessage(String),
+    EnableUpnp(Upnp, OneshotSender<Result<(), &'static str>>),
 }
 
 async fn task(
@@ -185,8 +199,9 @@ async fn task(
     mut events_handler: Box<dyn RuntimeEvents>,
     topic: Topic,
     mut rx: Receiver<RuntimeAction>,
-    upnp: Option<Upnp>,
 ) {
+    let mut upnp = None;
+
     loop {
         trace!(target: "locha-p2p", "loop");
 
@@ -219,10 +234,36 @@ async fn task(
                             );
                         }
                     }
+                    RuntimeAction::EnableUpnp(upnp_ref, tx) => {
+                        if upnp.is_none() {
+                            upnp = Some(upnp_ref);
+
+                            let addrs: Vec<Multiaddr> = Swarm::listeners(&swarm)
+                                .map(|a| a.clone())
+                                .collect();
+
+                            let mut ok = true;
+                            'map: for addr in addrs {
+                                if check_port_mapping(upnp.as_ref().unwrap(), &addr).await.is_err() {
+                                    upnp = None;
+                                    ok = false;
+                                    break 'map;
+                                }
+                            }
+
+                            if ok {
+                                tx.send(Ok(())).ok();
+                            } else {
+                                tx.send(Err("UPnP handle is invalid")).ok();
+                            }
+                        } else {
+                            tx.send(Err("UPnP has been already set")).ok();
+                        }
+                    }
                 }
             },
             ev = swarm.next_event().fuse() => {
-                handle_event(&mut swarm, upnp.as_ref(), &mut *events_handler, &ev).await;
+                handle_event(&mut swarm, &mut upnp, &mut *events_handler, &ev).await;
             },
         }
     }
@@ -230,7 +271,7 @@ async fn task(
 
 async fn handle_event<THandleErr: std::error::Error>(
     swarm: &mut Swarm,
-    upnp: Option<&Upnp>,
+    upnp: &mut Option<Upnp>,
     events_handler: &mut dyn RuntimeEvents,
     swarm_event: &SwarmEvent<NetworkEvent, THandleErr>,
 ) {
@@ -303,8 +344,11 @@ async fn handle_event<THandleErr: std::error::Error>(
             events_handler.on_unknown_peer_unreachable_addr(address, error);
         }
         SwarmEvent::NewListenAddr(ref address) => {
-            if let Some(upnp) = upnp {
-                check_port_mapping(upnp, address).await;
+            if let Some(u) = upnp {
+                if check_port_mapping(u, address).await.is_err() {
+                    // Receiver was dropped, so we'll drop the handle to it.
+                    *upnp = None;
+                }
             }
             events_handler.on_new_listen_addr(address)
         }
@@ -353,7 +397,10 @@ fn handle_behaviour_event(
     }
 }
 
-async fn check_port_mapping(upnp: &Upnp, address: &Multiaddr) {
+async fn check_port_mapping(
+    upnp: &Upnp,
+    address: &Multiaddr,
+) -> Result<(), SendError> {
     use crate::upnp::Protocol as UpnpProtocol;
 
     trace!(target: "locha-p2p", "checking port mapping for {}", address);
@@ -369,7 +416,7 @@ async fn check_port_mapping(upnp: &Upnp, address: &Multiaddr) {
         (Some(Protocol::Ip4(_)), Some(Protocol::Udp(port))) => {
             (port, UpnpProtocol::Udp)
         }
-        _ => return,
+        _ => return Ok(()),
     };
 
     // Add port mapping using UPnP.
@@ -378,5 +425,5 @@ async fn check_port_mapping(upnp: &Upnp, address: &Multiaddr) {
         proto,
         port,
     )
-    .await;
+    .await
 }


### PR DESCRIPTION
We now have an `UpnpBehaviour` that checks for external addresses which may eventually be upgraded to map ports. This now checks for the address, informs libp2p about it and then every 20 minutes we check again if we have the same IPv4 address, if it differs we inform libp2p about it again.

This works with multiple listeners which is on my to do list, for example, to listen on multiple ports (because we can?) and can be useful in the near future.