### PR TITLE
Make UPnP use only one thread

### DIFF
--- a/locha-p2pd/src/main.rs
+++ b/locha-p2pd/src/main.rs
@@ -34,7 +34,6 @@ use locha_p2p::identity::Identity;
 use locha_p2p::runtime::config::RuntimeConfig;
 use locha_p2p::runtime::events::{RuntimeEvents, RuntimeEventsLogger};
 use locha_p2p::runtime::Runtime;
-use locha_p2p::upnp::Upnp;
 
 use log::{info, trace};
 
@@ -168,13 +167,6 @@ async fn main() {
         echo: arguments.echo,
     };
 
-    let (upnp, upnp_task) = Upnp::new();
-    task::spawn(upnp_task);
-
-    if let Some(ip) = upnp.get_external_ip_address().await.unwrap() {
-        info!(target: "locha-p2p", "UPnP: ExternalIPAddress={}", ip);
-    }
-
     let (runtime, runtime_task) = Runtime::new(
         config,
         Box::new(RuntimeEventsLogger::new(events_handler)),
@@ -188,9 +180,6 @@ async fn main() {
     for to_dial in arguments.dials {
         runtime.dial(to_dial).await
     }
-
-    // Enable UPnP port mapping
-    runtime.enable_upnp(upnp).await.unwrap();
 
     let input = io::stdin();
     let channel = receiver;

--- a/src/network.rs
+++ b/src/network.rs
@@ -18,11 +18,14 @@ use libp2p::NetworkBehaviour;
 
 use crate::discovery::{DiscoveryBehaviour, DiscoveryEvent};
 use crate::gossip::{Gossipsub, GossipsubEvent, PublishError, Topic};
-use crate::upnp::behaviour::UpnpBehaviour;
+use crate::upnp::UpnpBehaviour;
 
 use crate::identity::Identity;
 
 use void::Void;
+
+/// Node/agent version string.
+pub const AGENT_VERSION: &str = "Locha Mesh P2P 1.0.0";
 
 #[derive(NetworkBehaviour)]
 #[behaviour(event_process = false)]
@@ -44,13 +47,13 @@ impl Network {
             discovery,
             gossip: crate::gossip::new(identity),
             upnp: Toggle::from(if upnp {
-                Some(UpnpBehaviour::new())
+                Some(UpnpBehaviour::new(AGENT_VERSION.into()))
             } else {
                 None
             }),
             identify: Identify::new(
                 "/locha/identify/1.0.0".into(),
-                "Locha Mesh P2P 1.0.0".into(),
+                AGENT_VERSION.into(),
                 identity.keypair().public(),
             ),
         }

--- a/src/upnp.rs
+++ b/src/upnp.rs
@@ -13,147 +13,274 @@
 // limitations under the License.
 
 //! # UPnP
+//!
+//! This is the Universal Plug and Play (UPnP) `NetworkBehaviour`, this
+//! behaviour reports our external IPv4 address if we are behind a NATed
+//! router or a general IGD. It also maps all of the open TCP ports for the
+//! IPv4 listening addresses found.
+//!
+//! Each 20 minutes the address is checked and if it differs it's reported
+//! again. Also the ports get remapped in case a buggy UPnP implementation
+//! drops the mapping, other application messes with it, etc.
+//!
+//! # Usage
+//!
+//! ```rust
+//! use locha_p2p::upnp::UpnpBehaviour;
+//!
+//! const PROTOCOL_DESCRIPTION: &str = "My Great Protocol";
+//!
+//! let _upnp = UpnpBehaviour::new(PROTOCOL_DESCRIPTION.into());
+//! ```
 
-use std::collections::HashSet;
+use std::borrow::Cow;
+use std::collections::{HashSet, VecDeque};
+use std::iter::FromIterator;
 use std::net::Ipv4Addr;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 use std::time::Duration;
 
-use futures::channel::mpsc::{channel, Receiver, SendError, Sender};
-use futures::channel::oneshot::channel as oneshot_channel;
-use futures::channel::oneshot::Sender as OneshotSender;
-use futures::{Future, FutureExt, SinkExt, StreamExt};
+use futures::Future;
 
-use log::error;
+use libp2p::core::connection::ConnectionId;
+use libp2p::core::multiaddr::Protocol;
+use libp2p::swarm::protocols_handler::DummyProtocolsHandler;
+use libp2p::swarm::PollParameters;
+use libp2p::swarm::{NetworkBehaviour, NetworkBehaviourAction};
+use libp2p::{Multiaddr, PeerId};
 
-pub use miniupnpc::commands::Protocol;
+use wasm_timer::Delay;
 
-pub const CHECK_PORT_INTERVALS_SECS: u64 = 1200;
+use void::Void;
 
-#[derive(Debug, Clone)]
-pub struct Upnp {
-    tx: Sender<UpnpEvent>,
+use log::{error, info, trace};
+
+pub struct UpnpBehaviour {
+    interval: Option<Delay>,
+    observed_addr: Option<Ipv4Addr>,
+    pending_actions: VecDeque<NetworkBehaviourAction<Void, Void>>,
+    protocol_desc: Cow<'static, str>,
+    ports: HashSet<u16>,
 }
 
-impl Upnp {
-    pub fn new() -> (Upnp, impl Future<Output = ()> + Send + 'static) {
-        let (tx, rx) = channel(5);
-        (Upnp { tx }, task(rx))
+impl UpnpBehaviour {
+    /// Interval used for checking External IPv4 address and Port Mapping.
+    pub const INTERVAL: u64 = 1200;
+
+    /// Create a new [`UpnpBehaviour`]
+    ///
+    /// # Arguments
+    ///
+    /// - `protocol_desc`: Protocol description for the port mapping
+    /// for UPnP, it's usually displayed on the _User Interface_ of
+    /// some routers alongside the port map.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use locha_p2p::upnp::UpnpBehaviour;
+    ///
+    /// let _behaviour = UpnpBehaviour::new("My Great Protocol 1.0.0".into());
+    /// ```
+    pub fn new(protocol_desc: Cow<'static, str>) -> UpnpBehaviour {
+        UpnpBehaviour {
+            interval: None,
+            observed_addr: None,
+            pending_actions: VecDeque::new(),
+            protocol_desc,
+            ports: HashSet::new(),
+        }
     }
 
-    pub async fn get_external_ip_address(
-        &self,
-    ) -> Result<Option<Ipv4Addr>, SendError> {
-        let (tx, rx) = oneshot_channel();
-        self.tx
-            .clone()
-            .send(UpnpEvent::GetExternalIPAddress(tx))
-            .await?;
+    /// Update the listening ports and return the ports that were removed
+    /// from the set for further unmapping of these ports.
+    fn update_ports(&mut self, params: &impl PollParameters) -> HashSet<u16> {
+        let mut found = HashSet::new();
 
-        Ok(rx.await.unwrap())
-    }
+        for addr in params.listened_addresses() {
+            let mut iter = addr.iter();
 
-    pub async fn add_port_mapping(
-        &self,
-        desc: String,
-        proto: Protocol,
-        port: u16,
-    ) -> Result<(), SendError> {
-        self.tx
-            .clone()
-            .send(UpnpEvent::AddPortMapping(PortMap { desc, proto, port }))
-            .await
-    }
+            let (ip, port) = (iter.next(), iter.next());
 
-    pub async fn stop(&self) -> Result<(), SendError> {
-        self.tx.clone().send(UpnpEvent::Stop).await
-    }
-}
-
-#[derive(Debug)]
-enum UpnpEvent {
-    Stop,
-    GetExternalIPAddress(OneshotSender<Option<Ipv4Addr>>),
-    AddPortMapping(PortMap),
-}
-
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
-struct PortMap {
-    desc: String,
-    proto: Protocol,
-    port: u16,
-}
-
-async fn task(mut rx: Receiver<UpnpEvent>) {
-    let mut port_mappings: HashSet<PortMap> = HashSet::new();
-    let mut interval = async_std::stream::interval(Duration::from_secs(
-        CHECK_PORT_INTERVALS_SECS,
-    ));
-
-    loop {
-        futures::select_biased! {
-            event = rx.next().fuse() => {
-                let event = event.unwrap_or(UpnpEvent::Stop);
-
-                match event {
-                    UpnpEvent::GetExternalIPAddress(tx) => {
-                        tx.send(external_ip()).ok();
-                    }
-                    UpnpEvent::AddPortMapping(map) => {
-                        if port_mappings.get(&map).is_none() {
-                            port_mappings.insert(map.clone());
-                            match discover() {
-                                Ok(Some((urls, igd, lanaddr))) => {
-                                    miniupnpc::commands::add_port_mapping(
-                                        urls.control_url(),
-                                        igd.first().service_type(),
-                                        map.port,
-                                        map.port,
-                                        lanaddr,
-                                        map.desc,
-                                        map.proto,
-                                        None,
-                                        Duration::from_secs(0),
-                                    )
-                                    .ok();
-                                }
-                                Ok(None) | Err(_) => {}
-                            }
-                        }
-                    }
-                    UpnpEvent::Stop => return,
-                };
-            },
-            _ = interval.next().fuse() => {
-                // If any port mapping, remap them because we don't know
-                // if the map was kept on the UPnP IGD, so... for reliability
-                // just remap again.
-                //
-                // This might actually help in the case the IGD is reset, or
-                // any other reason. Doing this each 20 mins (1200 s) does not
-                // hurts performance.
-                if port_mappings.len() > 0 {
-                    match discover() {
-                        Ok(Some((urls, igd, lanaddr))) => {
-                            for map in port_mappings.iter() {
-                                miniupnpc::commands::add_port_mapping(
-                                    urls.control_url(),
-                                    igd.first().service_type(),
-                                    map.port,
-                                    map.port,
-                                    lanaddr,
-                                    &map.desc,
-                                    map.proto,
-                                    None,
-                                    Duration::from_secs(0),
-                                )
-                                .ok();
-                            }
-                        }
-                        Ok(None) | Err(_) => (),
-                    };
-                }
+            if let (Some(Protocol::Ip4(_)), Some(Protocol::Tcp(port))) =
+                (ip, port)
+            {
+                found.insert(port);
             }
         }
+
+        // Keep ones found and report the difference so they get unmapped
+        let diff: HashSet<u16> =
+            self.ports.symmetric_difference(&found).copied().collect();
+
+        self.ports = found;
+
+        diff
+    }
+
+    /// Update our external IPv4 address by asking IGDs on our network.
+    fn update_ip(
+        &mut self,
+    ) -> Option<(miniupnpc::Urls, miniupnpc::IgdData, Ipv4Addr)> {
+        match discover() {
+            Ok(Some((urls, data, lanaddr))) => {
+                self.observed_addr =
+                    miniupnpc::commands::get_external_ip_address(
+                        urls.control_url(),
+                        data.first().service_type(),
+                    )
+                    .ok();
+
+                Some((urls, data, lanaddr))
+            }
+            Ok(None) | Err(_) => None,
+        }
+    }
+
+    /// Reset the interval timer
+    fn reset_timer(&mut self) {
+        let delay = Delay::new(Duration::from_secs(Self::INTERVAL));
+        self.interval = Some(delay);
+    }
+
+    #[inline(always)]
+    fn last_report(&mut self) -> Option<NetworkBehaviourAction<Void, Void>> {
+        self.pending_actions.pop_front()
+    }
+}
+
+impl NetworkBehaviour for UpnpBehaviour {
+    type ProtocolsHandler = DummyProtocolsHandler;
+    type OutEvent = Void;
+
+    fn new_handler(&mut self) -> Self::ProtocolsHandler {
+        DummyProtocolsHandler::default()
+    }
+
+    fn addresses_of_peer(&mut self, _: &PeerId) -> Vec<Multiaddr> {
+        vec![]
+    }
+
+    fn inject_connected(&mut self, _: &PeerId) {}
+
+    fn inject_disconnected(&mut self, _: &PeerId) {}
+
+    fn inject_event(&mut self, _: PeerId, _: ConnectionId, ev: Void) {
+        match ev {}
+    }
+
+    fn poll(
+        &mut self,
+        cx: &mut Context<'_>,
+        params: &mut impl PollParameters,
+    ) -> Poll<NetworkBehaviourAction<Void, Void>> {
+        let is_first_poll =
+            self.interval.is_none() && self.observed_addr.is_none();
+        if is_first_poll {
+            self.update_ports(params);
+
+            if self.ports.is_empty() {
+                self.reset_timer();
+                return Poll::Pending;
+            }
+
+            self.update_ip();
+
+            if let Some(ref ip) = self.observed_addr {
+                for port in self.ports.iter() {
+                    let parts = vec![Protocol::Ip4(*ip), Protocol::Tcp(*port)];
+                    let address = Multiaddr::from_iter(parts);
+
+                    trace!(
+                        target: "locha-p2p",
+                        "UPnP: Observed address {}",
+                        address
+                    );
+
+                    self.pending_actions.push_back(
+                        NetworkBehaviourAction::ReportObservedAddr { address },
+                    );
+                }
+
+                self.reset_timer();
+                return Poll::Ready(self.last_report().unwrap());
+            } else {
+                self.reset_timer();
+                return Poll::Pending;
+            }
+        }
+
+        // Dispatch pending events first
+        if let Some(report) = self.last_report() {
+            return Poll::Ready(report);
+        }
+
+        // unwrap on interval is fine because is_first_poll was false.
+        let interval = self.interval.as_mut().unwrap();
+        match Pin::new(interval).poll(cx) {
+            Poll::Ready(_) => {
+                trace!(
+                    target: "locha-p2p",
+                    "periodic check of external IP and port mapping"
+                );
+
+                // TODO: unmap these ports!
+                let _unmap = self.update_ports(params);
+                let igd = self.update_ip();
+
+                if let Some(ref ip) = self.observed_addr {
+                    for port in self.ports.iter() {
+                        if let Some((ref urls, ref data, ref lanaddr)) = igd {
+                            let res = miniupnpc::commands::add_port_mapping(
+                                urls.control_url(),
+                                data.first().service_type(),
+                                *port,
+                                *port,
+                                *lanaddr,
+                                &self.protocol_desc,
+                                miniupnpc::commands::Protocol::Tcp,
+                                None,
+                                Duration::from_secs(0),
+                            );
+
+                            if res.is_ok() {
+                                info!(
+                                    target: "locha-p2p",
+                                    "UPnP: Port {} mapped successfully",
+                                    port
+                                );
+                            }
+                        }
+
+                        let parts =
+                            vec![Protocol::Ip4(*ip), Protocol::Tcp(*port)];
+                        let address = Multiaddr::from_iter(parts);
+
+                        trace!(
+                            target: "locha-p2p",
+                            "UPnP: Observed address {}",
+                            address
+                        );
+
+                        self.pending_actions.push_back(
+                            NetworkBehaviourAction::ReportObservedAddr {
+                                address,
+                            },
+                        );
+                    }
+                }
+
+                if let Some(report) = self.last_report() {
+                    return Poll::Ready(report);
+                }
+
+                self.reset_timer();
+            }
+            Poll::Pending => (),
+        }
+
+        Poll::Pending
     }
 }
 
@@ -180,201 +307,5 @@ fn discover() -> Result<
             Ok(Some((igd.urls, igd.data.unwrap(), igd.lan_address)))
         }
         None => Ok(None),
-    }
-}
-
-fn external_ip() -> Option<Ipv4Addr> {
-    if let Ok(Some((urls, igd, _))) = discover() {
-        miniupnpc::commands::get_external_ip_address(
-            urls.control_url(),
-            igd.first().service_type(),
-        )
-        .ok()
-    } else {
-        None
-    }
-}
-
-pub mod behaviour {
-    use super::external_ip;
-
-    use std::collections::{HashSet, VecDeque};
-    use std::iter::FromIterator;
-    use std::net::Ipv4Addr;
-    use std::pin::Pin;
-    use std::task::{Context, Poll};
-    use std::time::Duration;
-
-    use futures::Future;
-
-    use libp2p::core::connection::ConnectionId;
-    use libp2p::core::multiaddr::Protocol;
-    use libp2p::swarm::protocols_handler::DummyProtocolsHandler;
-    use libp2p::swarm::PollParameters;
-    use libp2p::swarm::{NetworkBehaviour, NetworkBehaviourAction};
-    use libp2p::{Multiaddr, PeerId};
-
-    use wasm_timer::Delay;
-
-    use void::Void;
-
-    use log::trace;
-
-    pub struct UpnpBehaviour {
-        interval: Option<Delay>,
-        observed_addr: Option<Ipv4Addr>,
-        pending_actions: VecDeque<NetworkBehaviourAction<Void, Void>>,
-    }
-
-    impl UpnpBehaviour {
-        pub fn new() -> UpnpBehaviour {
-            UpnpBehaviour {
-                interval: None,
-                observed_addr: None,
-                pending_actions: VecDeque::new(),
-            }
-        }
-    }
-
-    impl Default for UpnpBehaviour {
-        fn default() -> Self {
-            Self::new()
-        }
-    }
-
-    impl NetworkBehaviour for UpnpBehaviour {
-        type ProtocolsHandler = DummyProtocolsHandler;
-        type OutEvent = Void;
-
-        fn new_handler(&mut self) -> Self::ProtocolsHandler {
-            DummyProtocolsHandler::default()
-        }
-
-        fn addresses_of_peer(&mut self, _: &PeerId) -> Vec<Multiaddr> {
-            vec![]
-        }
-
-        fn inject_connected(&mut self, _: &PeerId) {}
-
-        fn inject_disconnected(&mut self, _: &PeerId) {}
-
-        fn inject_event(&mut self, _: PeerId, _: ConnectionId, ev: Void) {
-            match ev {}
-        }
-
-        fn poll(
-            &mut self,
-            cx: &mut Context<'_>,
-            params: &mut impl PollParameters,
-        ) -> Poll<NetworkBehaviourAction<Void, Void>> {
-            fn guess_ports(params: &impl PollParameters) -> HashSet<u16> {
-                let mut ports = HashSet::new();
-
-                for addr in params.listened_addresses() {
-                    let mut iter = addr.iter();
-
-                    let (ip, port) = (iter.next(), iter.next());
-
-                    if let (Some(Protocol::Ip4(_)), Some(Protocol::Tcp(port))) =
-                        (ip, port)
-                    {
-                        ports.insert(port);
-                    }
-                }
-
-                trace!(target: "locha-p2p", "ports: {:?}", ports);
-
-                ports
-            }
-
-            // Dispatch pending events first
-            if let Some(action) = self.pending_actions.pop_front() {
-                return Poll::Ready(action);
-            }
-
-            if self.interval.is_none() && self.observed_addr.is_none() {
-                let ports = guess_ports(params);
-                if ports.is_empty() {
-                    self.interval = Some(Delay::new(Duration::from_secs(1200)));
-                    return Poll::Pending;
-                }
-
-                self.observed_addr = external_ip();
-                self.interval = Some(Delay::new(Duration::from_secs(1200)));
-
-                if let Some(ref ip) = self.observed_addr {
-                    for port in ports {
-                        let parts =
-                            vec![Protocol::Ip4(*ip), Protocol::Tcp(port)];
-                        let address = Multiaddr::from_iter(parts);
-
-                        trace!(
-                            target: "locha-p2p",
-                            "observed address {}",
-                            address
-                        );
-
-                        self.pending_actions.push_back(
-                            NetworkBehaviourAction::ReportObservedAddr {
-                                address,
-                            },
-                        );
-                    }
-
-                    return Poll::Ready(
-                        self.pending_actions.pop_front().unwrap(),
-                    );
-                } else {
-                    return Poll::Pending;
-                }
-            }
-
-            let ports = guess_ports(params);
-            if self.interval.is_some() && !ports.is_empty() {
-                let interval = self.interval.as_mut().unwrap();
-
-                match Pin::new(interval).poll(cx) {
-                    Poll::Ready(_) => {
-                        trace!(target: "locha-p2p", "periodic check of external IP");
-                        let addr = external_ip();
-
-                        if addr.is_some() && self.observed_addr.is_some() {
-                            let new = addr.as_ref().unwrap();
-                            let old = addr.as_ref().unwrap();
-
-                            if new != old {
-                                self.observed_addr = addr;
-                            }
-                        }
-
-                        if let Some(ref ip) = self.observed_addr {
-                            for port in ports {
-                                let parts = vec![
-                                    Protocol::Ip4(*ip),
-                                    Protocol::Tcp(port),
-                                ];
-                                let address = Multiaddr::from_iter(parts);
-
-                                self.pending_actions.push_back(
-                                    NetworkBehaviourAction::ReportObservedAddr {
-                                        address,
-                                    },
-                                );
-                            }
-                        }
-
-                        self.interval =
-                            Some(Delay::new(Duration::from_secs(1200)));
-                    }
-                    Poll::Pending => (),
-                }
-            }
-
-            if let Some(action) = self.pending_actions.pop_front() {
-                return Poll::Ready(action);
-            }
-
-            Poll::Pending
-        }
     }
 }


### PR DESCRIPTION
The `Upnp` structure was removed, now `UpnpBehaviour` handles
port mapping of all our listening addresses. Small documentation
was added for the `upnp` module.