### PR TITLE
Add code coverage testing with cargo-tarpaulin

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,3 +41,12 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
+
+      - name: Run cargo-tarpaulin
+        uses: actions-rs/tarpaulin@v0.1.2
+        with:
+          version: '0.14.3'
+          args: '-- --test-threads 1'
+
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v1


### PR DESCRIPTION
**Description**
Builds tests, checks coverage and uploads the results to codecov.io (setup needed I think).

**Testing**
Wait for Github Actions to do it's magic.

**See also**
- [Codecov.io Quick Start](https://docs.codecov.io/docs/quick-start)
- #27 