### PR TITLE
Fix UPnP timer bug

### DIFF
--- a/src/upnp.rs
+++ b/src/upnp.rs
@@ -271,11 +271,11 @@ impl NetworkBehaviour for UpnpBehaviour {
                     }
                 }
 
+                self.reset_timer();
+
                 if let Some(report) = self.last_report() {
                     return Poll::Ready(report);
                 }
-
-                self.reset_timer();
             }
             Poll::Pending => (),
         }


### PR DESCRIPTION
Position matters, it should be before the return otherwise it won't get reset.