### PR TITLE
Implement Kademlia DHT random walking

### DIFF
--- a/locha-p2pd/src/main.rs
+++ b/locha-p2pd/src/main.rs
@@ -52,7 +52,6 @@ async fn main() {
 
     discovery
         .use_mdns(arguments.use_mdns)
-        .id(identity.id())
         .allow_ipv4_private(arguments.allow_ipv4_private)
         .allow_ipv4_shared(arguments.allow_ipv4_shared)
         .allow_ipv6_ula(arguments.allow_ipv6_ula);

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -44,7 +44,6 @@ pub struct DiscoveryConfig {
     allow_ipv4_private: bool,
     allow_ipv4_shared: bool,
     allow_ipv6_ula: bool,
-    id: Option<PeerId>,
 
     bootstrap: Vec<(PeerId, Multiaddr)>,
 }
@@ -58,7 +57,6 @@ impl DiscoveryConfig {
             allow_ipv4_private: false,
             allow_ipv4_shared: false,
             allow_ipv6_ula: false,
-            id: None,
 
             bootstrap: Vec::new(),
         };
@@ -116,12 +114,6 @@ impl DiscoveryConfig {
         self
     }
 
-    /// Peer Id of the node discovering peers.
-    pub fn id(&mut self, id: PeerId) -> &mut Self {
-        self.id = Some(id);
-        self
-    }
-
     /// Add a bootstrap address for Kademlia DHT
     pub fn add_address(
         &mut self,
@@ -151,12 +143,10 @@ pub struct DiscoveryBehaviour {
 }
 
 impl DiscoveryBehaviour {
-    pub fn with_config(mut config: DiscoveryConfig) -> DiscoveryBehaviour {
-        let id = config
-            .id
-            .clone()
-            .expect("PeerId is necessary to participate in Peer Discovery");
-
+    pub fn with_config(
+        id: PeerId,
+        mut config: DiscoveryConfig,
+    ) -> DiscoveryBehaviour {
         let mut kad_config = KademliaConfig::default();
         kad_config.set_protocol_name(LOCHA_KAD_PROTOCOL_NAME);
 
@@ -477,9 +467,9 @@ pub mod tests {
 
     #[test]
     fn test_is_address_not_allowed() {
-        let mut config = DiscoveryConfig::new(false);
-        config.id(Identity::generate().id());
-        let discovery = DiscoveryBehaviour::with_config(config);
+        let config = DiscoveryConfig::new(false);
+        let discovery =
+            DiscoveryBehaviour::with_config(Identity::generate().id(), config);
 
         assert!(discovery
             .is_address_not_allowed(&"/ip4/192.168.0.1".parse().unwrap()));

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -541,9 +541,24 @@ pub mod tests {
     use crate::identity::Identity;
 
     #[test]
-    fn test_discovery_config_bootstrap_nodes() {
+    fn test_discovery_config() {
         // We expect here for parsing of bootstrap nodes to go very well
-        DiscoveryConfig::new(true);
+        let mut config = DiscoveryConfig::new(true);
+
+        config
+            .max_connections(10)
+            .allow_ipv4_private(true)
+            .allow_ipv4_shared(true)
+            .allow_ipv6_ula(true);
+
+        assert_eq!(
+            config.bootstrap[0].0.to_string(),
+            "16Uiu2HAm3U4JmNLwVfCypZX3hCLmVkcsdzEh8NHfPFcKRhsaJ8rf".to_string()
+        );
+        assert_eq!(config.max_connections, 10);
+        assert!(config.allow_ipv4_private);
+        assert!(config.allow_ipv4_shared);
+        assert!(config.allow_ipv6_ula);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,8 +56,7 @@ pub type Swarm = libp2p::Swarm<self::network::Network>;
 /// use locha_p2p::discovery::DiscoveryConfig;
 ///
 /// let id = Identity::generate();
-/// let mut discovery = DiscoveryConfig::new(false);
-/// discovery.id(id.id());
+/// let discovery = DiscoveryConfig::new(false);
 ///
 /// let _swarm = locha_p2p::build_swarm(&id, discovery, false).unwrap();
 /// ```
@@ -67,8 +66,10 @@ pub fn build_swarm(
     upnp: bool,
 ) -> Result<Swarm, std::io::Error> {
     let transport = build_transport(&identity.keypair())?;
-    let discovery =
-        self::discovery::DiscoveryBehaviour::with_config(discovery_config);
+    let discovery = self::discovery::DiscoveryBehaviour::with_config(
+        identity.id(),
+        discovery_config,
+    );
     let behaviour =
         self::network::Network::with_discovery(identity, discovery, upnp);
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -41,18 +41,13 @@
 //!
 //! let identity = Identity::generate();
 //!
-//! let mut discovery = DiscoveryConfig::new(true);
-//!
-//! discovery.id(identity.id());
-//!
 //! let config = RuntimeConfig {
 //!     identity,
 //!     listen_addr: "/ip4/0.0.0.0/tcp/0".parse().expect("invalid address"),
 //!     channel_cap: 20,
 //!     heartbeat_interval: 5,
 //!
-//!     // Yes, allow discovery of private IPv4 adddresses
-//!     discovery,
+//!     discovery: DiscoveryConfig::new(true),
 //! };
 //!
 //! let (runtime, runtime_task) = Runtime::new(config, Box::new(EventsHandler), false).unwrap();

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -96,6 +96,7 @@ use crate::PeerId;
 use crate::{build_swarm, Swarm};
 
 /// Locha P2P runtime
+#[derive(Clone)]
 pub struct Runtime {
     tx: Sender<RuntimeAction>,
 }


### PR DESCRIPTION
This can be tested right now as is, it will random walk the DHT with a random peer ID at intervals, changes by an order of 2 between each walk with a maximum time of 60 s. The discovery process stops when the maximum number of connections is reached.